### PR TITLE
Py2vs3 HTMLParser html.parser

### DIFF
--- a/chemdataextractor/cli/dict.py
+++ b/chemdataextractor/cli/dict.py
@@ -13,8 +13,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import re
-import HTMLParser
 import sys
+
+#HTMLParser is called html.parser in Python 3.X
+if (sys.version_info[0]<3):
+    import HTMLParser
+else:
+    import hmtl.parser as HTMLParser
 
 import click
 from ..nlp.lexicon import ChemLexicon

--- a/chemdataextractor/cli/dict.py
+++ b/chemdataextractor/cli/dict.py
@@ -19,7 +19,7 @@ import sys
 if (sys.version_info[0]<3):
     import HTMLParser
 else:
-    import hmtl.parser as HTMLParser
+    import html.parser as HTMLParser
 
 import click
 from ..nlp.lexicon import ChemLexicon

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-dateutil>=2.5.3
 requests>=2.11.1
 schematics>=1.1.1
 six>=1.10.0
+HTMLParser>=0.0.2


### PR DESCRIPTION
This correctly imports HTMLParser or html.parser for python 2.x or 3.x. For 3.x, imports html.parser as HTMLParser to simplify & reduce further incompatibility. See https://docs.python.org/2/library/htmlparser.html. 

