### PR TITLE
Fix issues with reference link extraction using HTML/XML readers

### DIFF
--- a/chemdataextractor/reader/markup.py
+++ b/chemdataextractor/reader/markup.py
@@ -165,13 +165,14 @@ class LxmlReader(six.with_metaclass(ABCMeta, BaseReader)):
     def _parse_reference(self, el):
         """Return reference ID from href or text content."""
         if el.get('href', '').startswith('#'):
+            # TODO: Get anchor from href with absolute url, e.g. http://pubs.acs.org/doi/full/10.1021/acs.jmedchem.6b01195#cor1
             return [el.get('href')[1:]]
         elif 'rid' in el.attrib:
             return [el.attrib['rid']]
         elif 'idref' in el.attrib:
             return [el.attrib['idref']]
         else:
-            return [el.text.strip()]
+            return [''.join(el.itertext()).strip()]
 
     def _parse_table(self, el, refs, specials):
         caps = self._css(self.table_caption_css, el)

--- a/chemdataextractor/reader/markup.py
+++ b/chemdataextractor/reader/markup.py
@@ -164,9 +164,8 @@ class LxmlReader(six.with_metaclass(ABCMeta, BaseReader)):
 
     def _parse_reference(self, el):
         """Return reference ID from href or text content."""
-        if el.get('href', '').startswith('#'):
-            # TODO: Get anchor from href with absolute url, e.g. http://pubs.acs.org/doi/full/10.1021/acs.jmedchem.6b01195#cor1
-            return [el.get('href')[1:]]
+        if '#' in el.get('href', ''):
+            return [el.get('href').split('#', 1)[1]]
         elif 'rid' in el.attrib:
             return [el.attrib['rid']]
         elif 'idref' in el.attrib:

--- a/tests/data/acs/acs.jmedchem.6b00723.html
+++ b/tests/data/acs/acs.jmedchem.6b00723.html
@@ -1,0 +1,6179 @@
+<!DOCTYPE html>
+<html lang="en" class="pb-page"  data-request-id="e6a5707d-2936-44f8-afc6-cb78ffaad48a"  
+><head data-pb-dropzone="head"><meta name="pbContext" content=";article:article:10.1021/acs.jmedchem.6b00723;journal:journal:jmcmar;page:string:Article/Chapter View;wgroup:string:ACHS website Group;website:website:acspubs;issue:issue:10.1021/jmcmar.ahead-of-print;pageGroup:string:Publication Pages;subPage:string:Full Text"/><meta data-pb-head="head-widgets-start"/>
+<link rel="schema.DC" href="http://purl.org/DC/elements/1.0/" /><meta name="dc.Title" content="Discovery of a Quinoline-4-carboxamide Derivative with a Novel Mechanism of Action, Multistage Antimalarial Activity, and Potent in Vivo Efficacy" /><meta name="dc.Creator" content="Beatriz Baragaña" /><meta name="dc.Creator" content="Neil R. Norcross" /><meta name="dc.Creator" content="Caroline Wilson" /><meta name="dc.Creator" content="Achim Porzelle" /><meta name="dc.Creator" content="Irene Hallyburton" /><meta name="dc.Creator" content="Raffaella Grimaldi" /><meta name="dc.Creator" content="Maria Osuna-Cabello" /><meta name="dc.Creator" content="Suzanne Norval" /><meta name="dc.Creator" content="Jennifer Riley" /><meta name="dc.Creator" content="Laste Stojanovski" /><meta name="dc.Creator" content="Frederick R. C. Simeons" /><meta name="dc.Creator" content="Paul G. Wyatt" /><meta name="dc.Creator" content="Michael J. Delves" /><meta name="dc.Creator" content="Stephan Meister" /><meta name="dc.Creator" content="Sandra Duffy" /><meta name="dc.Creator" content="Vicky M. Avery" /><meta name="dc.Creator" content="Elizabeth A. Winzeler" /><meta name="dc.Creator" content="Robert E. Sinden" /><meta name="dc.Creator" content="Sergio Wittlin" /><meta name="dc.Creator" content="Julie A. Frearson" /><meta name="dc.Creator" content="David W. Gray" /><meta name="dc.Creator" content="Alan H. Fairlamb" /><meta name="dc.Creator" content="David Waterson" /><meta name="dc.Creator" content="Simon F. Campbell" /><meta name="dc.Creator" content="Paul Willis" /><meta name="dc.Creator" content="Kevin D. Read" /><meta name="dc.Creator" content="Ian H. Gilbert" /><meta name="dc.Description" content="The antiplasmodial activity, DMPK properties, and efficacy of a series of quinoline-4-carboxamides are described. This series was identified from a phenotypic screen against the blood stage of Plasmodium falciparum (3D7) and displayed moderate potency but with suboptimal physicochemical properties and poor microsomal stability. The screening hit (1, EC50 = 120 nM) was optimized to lead molecules with low nanomolar in vitro potency. Improvement of the pharmacokinetic profile led to several compounds showing excellent oral efficacy in the P. berghei malaria mouse model with ED90 values below 1 mg/kg when dosed orally for 4 days. The favorable potency, selectivity, DMPK properties, and efficacy coupled with a novel mechanism of action, inhibition of translation elongation factor 2 (PfEF2), led to progression of 2 (DDD107498) to preclinical development." /><meta name="dc.Description" content="" /><meta name="dc.Publisher" content="American Chemical Society" /><meta name="dc.Date" scheme="WTN8601" content="September 10, 2016" /><meta name="dc.Type" content="research-article" /><meta name="dc.Format" content="text/HTML" /><meta name="dc.Identifier" scheme="doi" content="10.1021/acs.jmedchem.6b00723" /><meta name="dc.Language" content="EN" /><meta name="dc.Coverage" content="world" /><meta name="citation_fulltext_world_readable" content=""/>
+        
+        
+
+        
+            <link rel="meta" type="application/atom+xml" href="http://dx.doi.org/10.1021%2Facs.jmedchem.6b00723" />
+            <link rel="meta" type="application/rdf+json" href="http://dx.doi.org/10.1021%2Facs.jmedchem.6b00723" />
+            <link rel="meta" type="application/unixref+xml" href="http://dx.doi.org/10.1021%2Facs.jmedchem.6b00723" />
+        
+    <title>Discovery of a Quinoline-4-carboxamide Derivative with a Novel Mechanism of Action, Multistage Antimalarial Activity, and Potent in Vivo Efficacy - Journal of Medicinal Chemistry (ACS Publications)</title>
+
+
+
+
+
+
+
+
+
+
+<meta charset="UTF-8">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta data-pb-head="head-widgets-end"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<link rel="stylesheet" type="text/css" href="/wro/product.css"><link rel="stylesheet" type="text/css" href="/pb/css/t1476972046507-v1473772882000/head_1_46_183.css" id="pb-css" data-pb-css-id="t1476972046507-v1473772882000/head_1_46_183.css"/>
+
+
+<script type="text/javascript" src="/wro/product.js"></script>
+
+
+
+
+
+
+
+
+
+
+    
+        
+            <script type="text/javascript">
+                (function (i, s, o, g, r, a, m) {
+                    i['GoogleAnalyticsObject'] = r;
+                    i[r] = i[r] || function () {
+                                (i[r].q = i[r].q || []).push(arguments)
+                            }, i[r].l = 1 * new Date();
+                    a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+                    a.async = 1;
+                    a.src = g;
+                    m.parentNode.insertBefore(a, m)
+                })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+                ga('create', 'UA-7663985-4'
+                        ,'auto');
+                
+                ga('send', 'pageview');
+            </script>
+            
+        
+    
+
+
+
+
+
+
+
+    
+</head>
+<body class="pb-ui">
+
+
+
+
+
+
+    
+
+    <div id="pb-page-content" data-ng-non-bindable>
+        <div data-pb-dropzone="main" data-pb-dropzone-name="Main">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumAd none hide widget-none" id="8ffa8e02-92de-4357-aad5-3f0dbaea42df"  >
+        
+        
+            
+        
+
+        <div class="wrapped " id='dfp-global-variables'>
+            
+            <div class="widget-body body body-none "><div class="pb-ad">
+            <script type="text/javascript">
+	var dartInstitutionType = 'none';
+	var dartMember = 'false';
+</script>
+        </div></div>
+        </div>
+    </div>
+    
+
+
+
+
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none hide widget-none" id="7353141c-1e04-41fe-acd2-4be633212fe9"  >
+        
+        
+            
+        
+
+        <div class="wrapped " id='dfp-defineSlot-ad-settings'>
+            
+            <div class="widget-body body body-none "><script type='text/javascript'>
+	googletag.cmd.push(function() {
+		
+		//pubs
+		googletag.defineSlot('/8868/pubs/homepage', [[970, 90], [728, 90]], 'dfp-pubs-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+		googletag.defineSlot('/8868/pubs/homepage', [300, 250], 'dfp-pubs-rectangle-1').addService(googletag.pubads()).setTargeting('location', 'rectangle1');
+		googletag.defineSlot('/8868/pubs/homepage', [300, 250], 'dfp-pubs-rectangle-2').addService(googletag.pubads()).setTargeting('location', 'rectangle2');
+
+		//arrc
+		googletag.defineSlot('/8868/pubs/arrc', [[970, 90], [728, 90]], 'dfp-pubs-arrc-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+
+		//info central
+		googletag.defineSlot('/8868/pubs/infocentral', [[970, 90], [728, 90]], 'dfp-pubs-infocentral-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+
+		//books
+		googletag.defineSlot('/8868/pubs/books', [[970, 90], [728, 90]], 'dfp-pubs-books-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+		googletag.defineSlot('/8868/pubs/books', [300, 250], 'dfp-pubs-books-rectangle-1').addService(googletag.pubads()).setTargeting('location', 'rectangle1');
+		googletag.defineSlot('/8868/pubs/books', [300, 250], 'dfp-pubs-books-rectangle-2').addService(googletag.pubads()).setTargeting('location', 'rectangle2');
+
+		//search
+		googletag.defineSlot('/8868/search', [[970, 90], [728, 90]], 'dfp-pubs-search-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+		googletag.defineSlot('/8868/search', [728, 90], 'dfp-pubs-search-leaderboard-2').addService(googletag.pubads()).setTargeting('location', 'leaderboard2');
+
+
+		//journal home pages and secondary pages
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/homepage', [[970, 90], [728, 90]], 'dfp-journal-hp-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/homepage', [300, 250], 'dfp-journal-hp-rectangle-1').addService(googletag.pubads()).setTargeting('location', 'rectangle1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/homepage', [300, 250], 'dfp-journal-hp-rectangle-2').addService(googletag.pubads()).setTargeting('location', 'rectangle2');
+
+
+		//journal submission pages
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/submission', [[970, 90], [728, 90]], 'dfp-journal-submission-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/submission', [300, 250], 'dfp-journal-submission-rectangle-1').addService(googletag.pubads()).setTargeting('location', 'rectangle1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/submission', [300, 250], 'dfp-journal-submission-rectangle-2').addService(googletag.pubads()).setTargeting('location', 'rectangle2');
+
+		//journal loi
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/loi', [[970, 90], [728, 90]], 'dfp-journal-loi-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/loi', [300, 250], 'dfp-journal-loi-rectangle-1').addService(googletag.pubads()).setTargeting('location', 'rectangle1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/loi', [300, 250], 'dfp-journal-loi-rectangle-2').addService(googletag.pubads()).setTargeting('location', 'rectangle2');
+
+		//journal toc
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/toc', [[970, 90], [728, 90]], 'dfp-journal-toc-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/toc', [300, 250], 'dfp-journal-toc-rectangle-1').addService(googletag.pubads()).setTargeting('location', 'rectangle1');
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/toc', [300, 250], 'dfp-journal-toc-rectangle-2').addService(googletag.pubads()).setTargeting('location', 'rectangle2');
+
+		//journal articles
+		googletag.defineSlot('/8868/journal/medicinal_chemistry/article', [[970, 90], [728, 90]], 'dfp-journal-article-leaderboard').addService(googletag.pubads()).setTargeting('location', 'leaderboard1');
+
+		//googletag.pubads().enableSingleRequest();
+		googletag.pubads().collapseEmptyDivs();
+		googletag.pubads().setTargeting('inst',dartInstitutionType).setTargeting('memb',dartMember);
+		googletag.enableServices();
+	});
+</script></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html alignCenter  widget-none  widget-compact-all" id="04bfcfa3-b2c6-4308-ba8f-d2b4563303e5"  >
+        
+        
+            
+        
+
+        <div class="wrapped " id='dfp-large-leaderboard'>
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="adInfoLargeLeaderboard">
+	<div class="advertisement">
+		<a href="http://acsmediakit.org/acs-pubs/?utm_source=AdTop&amp;utm_medium=Pubs&amp;utm_campaign=CEN">ADVERTISEMENT</a>
+	</div>
+	<div class="dfp">
+		<div id='dfp-journal-article-leaderboard'>
+			<script type='text/javascript'>
+				googletag.cmd.push(function() { googletag.display('dfp-journal-article-leaderboard'); });
+			</script>
+		</div>
+	</div>
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget pageHeader none  widget-none  widget-compact-all" id="a044fa95-d38d-478f-b3f7-a600a053203d"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><header class="page-header">
+    <div data-pb-dropzone="main">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-two-columns none ACSTop widget-none  widget-compact-all" id="6694f0f6-790b-4772-884b-03e51ea2d9f2"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="pb-columns row-fluid ">
+    <div class="width_2_3">
+        <div data-pb-dropzone="left" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-inline-content none  widget-none  widget-compact-all" id="9a4402ad-cf74-4122-8431-1152edd75a15"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="inline-dropzone" data-pb-dropzone="content">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumNavigationLoginBar none  widget-none  widget-compact-all" id="adc37bbe-80d7-4bab-96ae-c0aef5c52c3b"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="loginBar">
+
+    
+    
+
+    
+    
+    
+    
+            
+                    <span class="individualUser">
+                       
+                           Welcome, 
+                       
+                        
+                                <a href="/action/showPreferences" id="indivLogin">
+                                    Matthew Swain
+                                </a>
+                            
+                         
+                     </span>
+                    <span class="profileLink">
+                        <a href="/action/showPreferences" id="profileButton">Your Profile</a>
+                     </span>
+                
+            <span class="logoutLink">
+                <a href="https://pubs.acs.org/action/doLogout?logoutRedirectUrl=https%3A%2F%2Fsso.acs.org%2Fidp%2Fglogout%3Fappid%3DLiteratum%26returnURL%3D">Log Out</a>
+            </span>
+            <img src="https://sso.acs.org/idp/heartbeat?appid=Literatum" class="ssoHeartBeat">
+        
+    <input type="hidden" id="forgotPasswordEndpoint" value="https://account.acs.org/ssoamweb/forgot/password">
+    
+    <input type="hidden" id="homeInstitutionUrl" value="https://pubs.acs.org/action/ssostart?redirectUri=%2Fdoi%2Ffull%2F10.1021%2Facs.jmedchem.6b00723">
+    <input type="hidden" id="statusEndpoint" value="https://sso.acs.org/idp/status">
+    <input type="hidden" id="clientID" value="Literatum">
+    <input type="hidden" id="logoutUrl" value="https://pubs.acs.org/action/doLogout?logoutRedirectUrl=https%3A%2F%2Fsso.acs.org%2Fidp%2Fglogout%3Fappid%3DLiteratum%26returnURL%3D">
+    <input type="hidden" id="compiledCssId" value="/pb/css/t1476972046507-v1473772882000/head_1_46_183.css">
+    <input type="hidden" class="confirmRegisterMsg" value="To register on this site, you must create an ACS ID on the ACS Society website (www.acs.org). After completing your registration, you will be returned back to the page you were viewing on the ACS Publications website (pubs.acs.org)."/>
+
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumCartLink none  widget-none  widget-compact-all" id="56a4702b-94e6-4a32-ac3b-698cf3c282d7"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><a href="https://pubs.acs.org/action/showCart">
+        
+        <div class="cartLabel " style="">
+                Cart
+        </div>
+    </a></div>
+        </div>
+    </div>
+    
+</div></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+    <div class="width_1_3">
+        <div data-pb-dropzone="right" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none nav-society widget-none  widget-compact-all" id="50fb196a-f0ca-4c00-a4d5-a6291ca4bcde"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><ul class="inline-list">
+   <li><a href="http://www.acs.org" title="American Chemical Society"><span>ACS</span></a></li>
+   <li class="activeLink"><a href="/" title="ACS Publications"><span>ACS Publications</span></a></li>
+   <li><a href="http://pubs.acs.org/cen/" title="Chemical &amp; Engineering News"><span>C&amp;EN</span></a></li>
+   <li><a href="http://www.cas.org/" title="Chemical Abstracts Service" target="cas"><span>CAS</span></a></li>
+</ul></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none nav-pubs-wrap widget-none  widget-compact-all" id="928bdca7-c3cc-462a-aea7-502152e0ceec"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><script type="text/javascript">
+$(function(){
+	$('#nav-pubs-clicklayer').hover(
+		function() {
+			hideAZ = setTimeout(function() {
+				$('#nav-pubs').toggleClass('showAzList');
+				$('#nav-pubs-clicklayer').toggle();
+			}, 1000);
+		}, function() {
+			clearTimeout(hideAZ);
+		}
+	).click(function(){
+		$('#nav-pubs').toggleClass('showAzList');
+		$('#nav-pubs-clicklayer').toggle();
+	});
+});
+function showAZList() {
+	$('#nav-pubs').toggleClass('showAzList');
+	$('#nav-pubs-clicklayer').toggle();
+}
+</script>
+
+<div id="nav-pubs" class="menuXml">
+
+	<a href="/" title="ACS Publications Home" class="pubslogo-small"><img src="/pb-assets/images/pubslogo-small.png" alt="ACS Publications" /></a>
+
+	<ul class="primaryNav">
+		<li class="journal-az-link">
+			<div class="overlay"></div>
+			<a href="#" onclick="showAZList();return false;">ACS Journals <span class="arrow"></span></a>
+		</li>
+
+		<li>
+			<a href="http://www.acschemworx.org">ACS ChemWorx</a>
+		</li>
+
+		<li>
+			<a href="/page/books/index.html">eBooks</a>
+		</li>
+
+		<li>
+			<a href="/series/styleguide">ACS Style Guide</a>
+		</li>
+
+		<li class="last">
+			<a href="/journal/cenear">C&amp;EN Archives</a>
+		</li>
+	</ul>
+
+	<div id="nav-pubs-clicklayer" style="display:none;"></div>
+	<div id="journal-az-layer">
+		<ul>
+			<li class="letter">A</li>
+			<li>
+				<a href="/journal/achre4">Accounts of Chemical Research</a>
+			</li>
+			<li>
+				<a href="/journal/aamick">ACS Applied Materials &amp; Interfaces</a>
+			</li>
+			<li>
+				<a href="/journal/abseba">ACS Biomaterials Science &amp; Engineering</a>
+			</li>
+			<li>
+				<a href="/journal/accacs">ACS Catalysis</a>
+			</li>
+			<li>
+				<a href="/journal/acscii">ACS Central Science</a>
+			</li>
+			<li>
+				<a href="/journal/acbcct">ACS Chemical Biology</a>
+			</li>
+			<li>
+				<a href="/journal/acncdm">ACS Chemical Neuroscience</a>
+			</li>
+			<li>
+				<a href="/journal/acsccc">ACS Combinatorial Science</a>
+				<ul>
+					<li>
+						<a href="/journal/jcchff">- Journal of Combinatorial Chemistry</a>
+					</li>
+				</ul>
+			</li>
+			<li>
+				<a href="/journal/aesccq">ACS Earth and Space Chemistry - New in 2017</a>
+			</li>
+			<li>
+				<a href="/journal/aelccp">ACS Energy Letters - New in 2016</a>
+			</li>
+			<li>
+				<a href="/journal/aidcbc">ACS Infectious Diseases</a>
+			</li>
+			<li>
+				<a href="/journal/amlccd">ACS Macro Letters</a>
+			</li>
+			<li>
+				<a href="/journal/amclct">ACS Medicinal Chemistry Letters</a>
+			</li>
+			<li>
+				<a href="/journal/ancac3">ACS Nano</a>
+			</li>
+            <li>
+				<a href="/journal/acsodf">ACS Omega - New in 2016 </a>
+			</li>
+			<li>
+				<a href="/journal/apchd5">ACS Photonics</a>
+			</li>
+			<li>
+				<a href="/journal/ascefj">ACS Sensors - New in 2016 </a>
+			</li>
+			<li>
+				<a href="/journal/ascecg">ACS Sustainable Chemistry &amp; Engineering</a>
+			</li>
+			<li>
+				<a href="/journal/asbcd6">ACS Synthetic Biology</a>
+			</li>
+			<li>
+				<a href="/journal/ancham">Analytical Chemistry</a>
+				<ul>
+					<li>
+						<a href="/loi/ancham">- I&amp;EC Analytical Edition</a>
+					</li>
+				</ul>
+			</li>
+
+			<li class="letter">B</li>
+			<li>
+				<a href="/journal/bichaw">Biochemistry</a>
+			</li>
+			<li>
+				<a href="/journal/bcches">Bioconjugate Chemistry</a>
+			</li>
+			<li>
+				<a href="/journal/bomaf6">Biomacromolecules</a>
+			</li>
+			<li>
+				<a href="/journal/bipret">Biotechnology Progress</a>
+			</li>
+
+			<li class="letter">C</li>
+			<li>
+				<a href="/journal/crtoec">Chemical Research in Toxicology</a>
+			</li>
+			<li>
+				<a href="/journal/chreay">Chemical Reviews</a>
+			</li>
+			<li>
+				<a href="/journal/cmatex">Chemistry of Materials</a>
+			</li>
+			<li>
+				<a href="/journal/cgdefu">Crystal Growth &amp; Design</a>
+			</li>
+		</ul>
+
+		<ul>
+			<li class="letter">E</li>
+			<li>
+				<a href="/journal/enfuem">Energy &amp; Fuels</a>
+			</li>
+			<li>
+				<a href="/journal/esthag">Environmental Science &amp; Technology</a>
+			</li>
+			<li>
+				<a href="/journal/estlcu">Environmental Science &amp; Technology Letters</a>
+			</li>
+
+			<li class="letter">I</li>
+			<li>
+				<a href="/journal/iechad">Industrial &amp; Engineering Chemistry</a>
+				<ul>
+					<li>
+						<a href="/journal/iechad.1">- Journal of Industrial &amp; Engineering Chemistry</a>
+					</li>
+				</ul>
+			</li>
+			<li>
+				<a href="/journal/iecred">Industrial &amp; Engineering Chemistry Research</a>
+				<ul>
+					<li>
+						<a href="/loi/iepdaw">- I&amp;EC Process Design and Development</a>
+					</li>
+					<li>
+						<a href="/loi/iecfa7">- I&amp;EC Fundamentals</a>
+					</li>
+					<li>
+						<a href="/loi/iepra6">- Product Research &amp; Development</a>
+					</li>
+					<li>
+						<a href="/loi/iepra6">- Product R&amp;D</a>
+					</li>
+					<li>
+						<a href="/loi/iepra6">- I&amp;EC Product Research and Development</a>
+					</li>
+				</ul>
+			</li>
+			<li>
+				<a href="/journal/inocaj">Inorganic Chemistry</a>
+			</li>
+
+			<li class="letter">J</li>
+			<li>
+				<a href="/journal/jacsat">Journal of the American Chemical Society</a>
+			</li>
+			<li>
+				<a href="/journal/jafcau">Journal of Agricultural and Food Chemistry</a>
+			</li>
+			<li>
+				<a href="/journal/jceaax">Journal of Chemical &amp; Engineering Data</a>
+				<ul>
+					<li>
+						<a href="/loi/jceaax">- I&amp;EC Chemical &amp; Engineering Data Series</a>
+					</li>
+				</ul>
+			</li>
+			<li>
+				<a href="/journal/jceda8">Journal of Chemical Education</a>
+			</li>
+			<li>
+				<a href="/journal/jcisd8">Journal of Chemical Information and Modeling</a>
+				<ul>
+					<li>
+						<a href="/loi/jcisd8">- Journal of Chemical Documentation</a>
+					</li>
+					<li>
+						<a href="/loi/jcisd8">- Journal of Chemical Information and Computer Sciences</a>
+					</li>
+				</ul>
+			</li>
+			<li>
+				<a href="/journal/jctcce">Journal of Chemical Theory and Computation</a>
+			</li>
+			<li>
+				<a href="/journal/jmcmar">Journal of Medicinal Chemistry</a>
+			</li>
+			<li>
+				<a href="/journal/jnprdf">Journal of Natural Products</a>
+			</li>
+			<li>
+				<a href="/journal/joceah">The Journal of Organic Chemistry</a>
+			</li>
+		</ul>
+
+		<ul>
+			<li class="letter">J (continued)</li>
+			<li>
+				<a href="/journal/jpcafh">The Journal of Physical Chemistry A</a>
+			</li>
+			<li>
+				<a href="/journal/jpcbfk">The Journal of Physical Chemistry B</a>
+			</li>
+			<li>
+				<a href="/journal/jpccck">The Journal of Physical Chemistry C</a>
+				<ul>
+					<li>
+						<a href="/loi/jpchax">- The Journal of Physical Chemistry</a>
+					</li>
+					<li>
+						<a href="/loi/jpchax">- The Journal of Physical and Colloid Chemistry</a>
+					</li>
+				</ul>
+			</li>
+			<li>
+				<a href="/journal/jpclcd">The Journal of Physical Chemistry Letters</a>
+			</li>
+			<li>
+				<a href="/journal/jprobs">Journal of Proteome Research</a>
+			</li>
+
+			<li class="letter">L</li>
+			<li>
+				<a href="/journal/langd5">Langmuir</a>
+			</li>
+
+			<li class="letter">M</li>
+			<li>
+				<a href="/journal/mamobx">Macromolecules</a>
+			</li>
+			<li>
+				<a href="/journal/mpohbp">Molecular Pharmaceutics</a>
+			</li>
+
+			<li class="letter">N</li>
+			<li>
+				<a href="/journal/nalefd">Nano Letters</a>
+			</li>
+
+			<li class="letter">O</li>
+			<li>
+				<a href="/journal/orlef7">Organic Letters</a>
+			</li>
+			<li>
+				<a href="/journal/oprdfk">Organic Process Research &amp; Development</a>
+			</li>
+			<li>
+				<a href="/journal/orgnd7">Organometallics</a>
+			</li>
+		</ul>
+	</div>
+
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-two-columns none pubsTop widget-none  widget-compact-all" id="a489a1a3-ebc5-4c6a-ba98-5e4aafb7c45e"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="pb-columns row-fluid gutterless">
+    <div class="width_13_24">
+        <div data-pb-dropzone="left" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none pagelogo widget-none  widget-compact-all" id="9c46435f-303e-45e1-bfa8-7ceb2b87a0ea"  >
+        
+        
+            
+        
+
+        <div class="wrapped " id='series-logo'>
+            
+            <div class="widget-body body body-none  body-compact-all"><a href="/journal/jmcmar"><img src="/covergifs/jmcmar/title.gif" alt="Journal of Medicinal Chemistry" /></a></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+    <div class="width_11_24">
+        <div data-pb-dropzone="right" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-frame none qs-tabs widget-none  widget-compact-all" id="6f8be75c-ee63-44de-ad5f-0ed027c19d78"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div data-pb-dropzone="contents">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none  widget-compact-all" id="757e478d-6239-4d7a-ac1c-9323ea098af3"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><a href="/search/advanced" class="advSearchLink">Advanced Search</a></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-tabs none  widget-none  widget-compact-all" id="3ab7fde8-8423-410a-89d0-b202c470a197"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="tabs tabs-widget " aria-live="polite" aria-atomic="true" aria-relevant="additions">
+    <ul class="tab-nav">
+        
+            <li class="active">
+                
+                        <a href="#3ab7fde8-8423-410a-89d0-b202c470a197-58132d06-cf2f-4e31-a696-f4f2aa0cdd9a" title="show Search" data-ga='[{"eventName":"_trackEvent"}, {"firstParam":"Quick Search"}, {"secondParam":"Search Tab"}]'>Search</a>
+                    
+            </li>
+        
+            <li class="">
+                
+                        <a href="#3ab7fde8-8423-410a-89d0-b202c470a197-b6de7b7c-de82-45a5-9538-313dd15c6659" title="show Citation" data-ga='[{"eventName":"_trackEvent"}, {"firstParam":"Quick Search"}, {"secondParam":"Citation Tab"}]'>Citation</a>
+                    
+            </li>
+        
+            <li class="">
+                
+                        <a href="#3ab7fde8-8423-410a-89d0-b202c470a197-c99a966e-255a-48ca-bc42-73e1dc1e0708" title="show Subject" data-ga='[{"eventName":"_trackEvent"}, {"firstParam":"Quick Search"}, {"secondParam":"Subject Tab"}]'>Subject</a>
+                    
+            </li>
+        
+    </ul>
+    <div class="tab-content">
+        
+            
+            
+                <div class="tab-pane active" id="3ab7fde8-8423-410a-89d0-b202c470a197-58132d06-cf2f-4e31-a696-f4f2aa0cdd9a">
+                    
+                    <div class="tab-pane-content" data-pb-dropzone="tab-58132d06-cf2f-4e31-a696-f4f2aa0cdd9a" data-pb-dropzone-name="Search">
+                        
+                            
+                                
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget quickSearchWidget none  widget-none  widget-compact-all" id="418cb9c3-dbc8-4fc8-bf37-ee58a4195363"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><util:actionContext></util:actionContext>
+
+
+
+
+
+
+
+        
+    
+
+
+
+<div class="quickSearchFormContainer">
+    
+
+    <form action="/action/doSearch" name="quickSearch" class="quickSearchForm " title="Quick Search" method="get"><span class="simpleSearchBoxContainer">
+                    
+                    
+                    
+                     
+                             <input name="AllField" class="searchText main-search-field autocomplete" value=""
+                                    type="search" title="Type search term here" placeholder="Enter search text / DOI" autocomplete="off"
+                                    type="search" id="searchText" title="Type search term here" placeholder="Enter search text / DOI" autocomplete="off"
+                                    data-history-items-conf="3"
+                                    data-publication-titles-conf="0"
+                                    data-topics-conf="0"
+                                    data-contributors-conf="0">
+                         
+                </span>
+                
+                    
+
+
+
+
+    
+
+<span class="citationSearchBoxContainer hidden">
+    <input name="quickLinkJournal" autoPopulate="true" data-auto-complete-target="Title" autoComplete="off" type="search" title="Journal or Book Series"
+           class="journalName mediumTextInput  autocomplete" placeholder="Journal or Book Series"/>
+
+        
+
+    <input type="hidden" name="quickLink" value="true" />
+    <input class="year smallTextInput" title="Year" type="search" name="quickLinkYear" value="" autocomplete="false" placeholder="Year" />
+    <input class="volume smallTextInput" title="Volume" type="search" name="quickLinkVolume" value="" autocomplete="false" placeholder="Volume" />
+    <input class="issue smallTextInput" title="Issue" type="search" name="quickLinkIssue" value="" autocomplete="false" placeholder="Issue" />
+    <input class="page smallTextInput" title="Page" type="search" name="quickLinkPage" value="" autocomplete="false" placeholder="Page" />
+</span>
+
+                
+            
+
+        
+            
+                
+
+
+
+
+
+
+
+
+
+
+
+<span class="searchDropDownDivRight">
+
+    <label for="searchInSelector" class="visuallyhidden">Search in:</label>
+    
+    <select id="searchInSelector" class="custom-dropdown js__searchInSelector">
+
+
+        <option value="" data-search-in="default">Anywhere</option>
+
+
+        
+            <option value="Title">
+                Title
+            </option>
+        
+
+        
+            <option value="Contrib">
+                Author
+            </option>
+        
+
+        
+            <option value="Abstract">
+                Abstract
+            </option>
+        
+
+
+    </select>
+
+
+</span>
+            
+        
+
+        
+            
+
+
+
+
+<input class="mainSearchButton searchButtons pointer" title="search" type="submit" value="Search" />
+        
+
+        
+        
+        
+
+
+
+
+
+
+    <input type="hidden" name="type" value="within" />
+    <div id="qsScope">
+        <label for="qsTitleButton" id="qsProduct">
+            <input id="qsTitleButton" type="radio" name="publication" value="40026035" checked="checked" />
+            <span>J. Med. Chem.</span>
+        </label>
+        <label for="qsAllButton" id="qsAll">
+            <input id="qsAllButton" type="radio" name="publication" value="" />
+            <span>All Publications/Website</span>
+        </label>
+    </div></form>
+</div>
+
+
+
+
+<div class="advancedSearchLinkDropZone" data-pb-dropzone="advancedSearchLinkDropZone">
+    
+</div></div>
+        </div>
+    </div>
+    
+
+                            
+                        
+                    </div>
+                </div>
+            
+        
+            
+            
+                <div class="tab-pane " id="3ab7fde8-8423-410a-89d0-b202c470a197-b6de7b7c-de82-45a5-9538-313dd15c6659">
+                    
+                    <div class="tab-pane-content" data-pb-dropzone="tab-b6de7b7c-de82-45a5-9538-313dd15c6659" data-pb-dropzone-name="Citation">
+                        
+                            
+                                
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget citationSearch none  widget-none  widget-compact-all" id="0cab95de-7577-441d-a5fe-3c4175aa325c"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="citationSearchContainer clear searchBox">
+
+    <form action="/action/quickLink" id="citationSearchForm" name="citationSearch" class="citationSearchForm" method="get"><fieldset>
+            <select name="quickLinkJournal" id="publicationSpan" class=" citationJournalName citation citation-search-title" data-placeholder="Journal or Book Series">
+
+                
+                    <option value="">Select a Journal or Book</option>
+                
+                            <option value="achre4">Acc. Chem. Res.</option>
+                        
+                            <option value="aamick">ACS Appl. Mater. Interfaces</option>
+                        
+                            <option value="abseba">ACS Biomater. Sci. Eng.</option>
+                        
+                            <option value="accacs">ACS Catal.</option>
+                        
+                            <option value="acscii">ACS Cent. Sci.</option>
+                        
+                            <option value="acbcct">ACS Chem. Biol.</option>
+                        
+                            <option value="acncdm">ACS Chem. Neurosci.</option>
+                        
+                            <option value="acsccc">ACS Comb. Sci.</option>
+                        
+                            <option value="aesccq">ACS Earth Space Chem.</option>
+                        
+                            <option value="aelccp">ACS Energy Lett.</option>
+                        
+                            <option value="aidcbc">ACS Infect. Dis.</option>
+                        
+                            <option value="amlccd">ACS Macro Lett.</option>
+                        
+                            <option value="amclct">ACS Med. Chem. Lett.</option>
+                        
+                            <option value="ancac3">ACS Nano</option>
+                        
+                            <option value="acsodf">ACS Omega</option>
+                        
+                            <option value="apchd5">ACS Photonics</option>
+                        
+                            <option value="ascefj">ACS Sens.</option>
+                        
+                            <option value="ascecg">ACS Sustainable Chem. Eng.</option>
+                        
+                            <option value="symposium">ACS Symposium Series</option>
+                        
+                            <option value="asbcd6">ACS Synth. Biol.</option>
+                        
+                            <option value="advances">Advances in Chemistry</option>
+                        
+                            <option value="ancham">Anal. Chem.</option>
+                        
+                            <option value="bichaw">Biochemistry</option>
+                        
+                            <option value="bcches">Bioconjugate Chem.</option>
+                        
+                            <option value="bomaf6">Biomacromolecules</option>
+                        
+                            <option value="bipret">Biotechnol. Prog.</option>
+                        
+                            <option value="crtoec">Chem. Res. Toxicol.</option>
+                        
+                            <option value="chreay">Chem. Rev.</option>
+                        
+                            <option value="cmatex">Chem. Mater.</option>
+                        
+                            <option value="cgdefu">Crystal Growth & Design</option>
+                        
+                            <option value="enfuem">Energy Fuels</option>
+                        
+                            <option value="esthag">Environ. Sci. Technol.</option>
+                        
+                            <option value="estlcu">Environ. Sci. Technol. Lett.</option>
+                        
+                            <option value="iechad">Ind. Eng. Chem.</option>
+                        
+                            <option value="iecred">Ind. Eng. Chem. Res.</option>
+                        
+                            <option value="iecnav">Ind. Eng. Chem., News Ed.</option>
+                        
+                            <option value="inocaj">Inorg. Chem.</option>
+                        
+                            <option value="jacsat">J. Am. Chem. Soc.</option>
+                        
+                            <option value="jafcau">J. Agric. Food Chem.</option>
+                        
+                            <option value="jceaax">J. Chem. Eng. Data</option>
+                        
+                            <option value="jceda8">J. Chem. Educ.</option>
+                        
+                            <option value="jcisd8">J. Chem. Inf. Model.</option>
+                        
+                            <option value="jctcce">J. Chem. Theory Comput.</option>
+                        
+                            <option value="jcchff">J. Comb. Chem.</option>
+                        
+                            <option value="jmcmar" selected>J. Med. Chem.</option>
+                        
+                            <option value="jnprdf">J. Nat. Prod.</option>
+                        
+                            <option value="joceah">J. Org. Chem.</option>
+                        
+                            <option value="jpchax">J. Phys. Chem.</option>
+                        
+                            <option value="jpcafh">J. Phys. Chem. A</option>
+                        
+                            <option value="jpcbfk">J. Phys. Chem. B</option>
+                        
+                            <option value="jpccck">J. Phys. Chem. C</option>
+                        
+                            <option value="jpclcd">J. Phys. Chem. Lett.</option>
+                        
+                            <option value="jprobs">J. Proteome Res.</option>
+                        
+                            <option value="langd5">Langmuir</option>
+                        
+                            <option value="mamobx">Macromolecules</option>
+                        
+                            <option value="mpohbp">Mol. Pharmaceutics</option>
+                        
+                            <option value="nalefd">Nano Lett.</option>
+                        
+                            <option value="neaca9">News Ed., Am. Chem. Soc</option>
+                        
+                            <option value="orlef7">Org. Lett.</option>
+                        
+                            <option value="oprdfk">Org. Process Res. Dev.</option>
+                        
+                            <option value="orgnd7">Organometallics</option>
+                        
+            </select>
+
+            <div class="citation-details float-right">
+                <input type="hidden" name="quickLink" value="true" /><input class="search-term smallTextInput" type="text" name="quickLinkVolume" value="" size="15" autocomplete="false" placeholder="vol" /><input class="search-term fist-page-input smallTextInput" type="text" name="quickLinkPage" value="" size="15" autocomplete="false" placeholder="page" />
+            </div>
+
+            <div class=" submitRow float-right clear">
+                <input id="citationSearchSubmitButton" class="searchButtons pointer" title="Citation Search" type="submit" value="Citation Search" disabled="disabled" />
+            </div>
+        </fieldset></form>
+</div></div>
+        </div>
+    </div>
+    
+
+                            
+                        
+                    </div>
+                </div>
+            
+        
+            
+            
+                <div class="tab-pane " id="3ab7fde8-8423-410a-89d0-b202c470a197-c99a966e-255a-48ca-bc42-73e1dc1e0708">
+                    
+                    <div class="tab-pane-content" data-pb-dropzone="tab-c99a966e-255a-48ca-bc42-73e1dc1e0708" data-pb-dropzone-name="Subject">
+                        
+                            
+                                
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none cas-subjects widget-none  widget-compact-all" id="a2c67375-3889-40bd-9d92-6ae9bbd61c7d"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><script type="text/javascript">
+function toggleSubjects(li) {
+	if ($(li).hasClass("open")) {
+		$(li).removeClass("open");
+	}
+	else {
+		$(li).parent().find('.category').removeClass("open");
+		$(li).addClass("open");
+	}
+	return false;
+}
+$(function(){
+	$('#qs-subjects .close-tab').click(function() {
+		$('.qs-tabs .tab-nav a').first().click();
+	});
+});
+</script>
+
+<div class="container collection" id="qs-subjects" style="display: block;">
+
+	<a class="close-tab">x</a>
+    
+    <div><strong>Select a <a href="http://cas.org" target="_blank">CAS</a> section from the 5 main topical divisions below:</strong></div>
+    <ul class="collectionList">
+        
+        <li class="category open">
+            <a title="View this subject category" onclick="toggleSubjects($(this).parent());" href="#"><span class="plusMinus">&nbsp;</span>
+                <span class="categoryTitle">Applied</span>
+            </a>
+            <div class="wrapper">
+                <ul>
+                    
+                    <li>
+                        <a href="/topic/industrial_hygiene">Air Pollution and Industrial Hygiene</a>
+                    </li>
+                    <li>
+                        <a href="/topic/plant_equipment">Apparatus and Plant Equipment</a>
+                    </li>
+                    <li>
+                        <a href="/topic/building_materials">Cement, Concrete, and Related Building Materials</a>
+                    </li>
+                    <li>
+                        <a href="/topic/ceramics">Ceramics</a>
+                    </li>
+                    <li>
+                        <a href="/topic/thermal_energy">Electrochemical, Radiational, and Thermal Energy Technology</a>
+                    </li>
+                    <li>
+                        <a href="/topic/cosmetics">Essential Oils and Cosmetics</a>
+                    </li>
+                    <li>
+                        <a href="/topic/metallurgy">Extractive Metallurgy</a>
+                    </li>
+                    <li>
+                        <a href="/topic/ferrous">Ferrous Metals and Alloys</a>
+                    </li>
+                    <li>
+                        <a href="/topic/fossil_fuels">Fossil Fuels, Derivatives, and Related Products</a>
+                    </li>
+                    <li>
+                        <a href="/topic/industrial_inorg_chem">Industrial Inorganic Chemicals</a>
+                    </li>
+                    <li>
+                        <a href="/topic/mineralogical_geological">Mineralogical and Geological Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/nonferrous">Nonferrous Metals and Alloys</a>
+                    </li>
+                    <li>
+                        <a href="/topic/pharm_analysis">Pharmaceutical Analysis</a>
+                    </li>
+                    <li>
+                        <a href="/topic/pharmaceuticals">Pharmaceuticals</a>
+                    </li>
+                    <li>
+                        <a href="/topic/propellants">Propellants and Explosives</a>
+                    </li>
+                    <li>
+                        <a href="/topic/unit_operations">Unit Operations and Processes</a>
+                    </li>
+                    <li>
+                        <a href="/topic/waste">Waste Treatment and Disposal</a>
+                    </li>
+                    <li>
+                        <a href="/topic/water">Water</a>
+                    </li>
+                </ul>
+            </div>
+        </li>
+
+        
+        <li class="category">
+            <a title="View this subject category" onclick="toggleSubjects($(this).parent());" href="JavaScript:void(0);"><span class="plusMinus">&nbsp;</span>
+                <span class="categoryTitle">Biochemistry</span>
+            </a>
+            <div class="wrapper">
+                <ul>
+                    
+                    <li>
+                        <a href="/topic/agrochem_bioregulators">Agrochemical Bioregulators</a>
+                    </li>
+                    <li>
+                        <a href="/topic/animal_nutrition">Animal Nutrition</a>
+                    </li>
+                    <li>
+                        <a href="/topic/biochem_genetics">Biochemical Genetics</a>
+                    </li>
+                    <li>
+                        <a href="/topic/biochem_methods">Biochemical Methods</a>
+                    </li>
+                    <li>
+                        <a href="/topic/enzymes">Enzymes</a>
+                    </li>
+                    <li>
+                        <a href="/topic/fermentation">Fermentation and Bioindustrial Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/fertilizers">Fertilizers, Soils, and Plant Nutrition</a>
+                    </li>
+                    <li>
+                        <a href="/topic/food_chemistry">Food and Feed Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/general_biochem">General Biochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/history_education">History, Education, and Documentation</a>
+                    </li>
+                    <li>
+                        <a href="/topic/immunochem">Immunochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/mammalian_biochem">Mammalian Biochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/mammalian_hormones">Mammalian Hormones</a>
+                    </li>
+                    <li>
+                        <a href="/topic/mammalian_path_biochem">Mammalian Pathological Biochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/microbial_biochem">Microbial, Algal, and Fungal Biochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/nonmammalian_biochem">Nonmammalian Biochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/pharmacology">Pharmacology</a>
+                    </li>
+                    <li>
+                        <a href="/topic/plant_biochem">Plant Biochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/radiation_biochem">Radiation Biochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/toxicology">Toxicology</a>
+                    </li>
+                </ul>
+            </div>
+        </li>
+
+        
+        <li class="category">
+            <a title="View this subject category" onclick="toggleSubjects($(this).parent());" href="JavaScript:void(0);"><span class="plusMinus">&nbsp;</span>
+                <span class="categoryTitle">Macromolecular</span>
+            </a>
+            <div class="wrapper">
+                <ul>
+                    
+                    <li>
+                        <a href="/topic/wood_products">Cellulose, Lignin, Paper, and Other Wood Products</a>
+                    </li>
+                    <li>
+                        <a href="/topic/polymer_chem">Chemistry of Synthetic High Polymers</a>
+                    </li>
+                    <li>
+                        <a href="/topic/coatings_inks">Coatings, Inks, and Related Products</a>
+                    </li>
+                    <li>
+                        <a href="/topic/dyes">Dyes, Organic Pigments, Fluorescent Brighteners, and Photographic Sensitizers</a>
+                    </li>
+                    <li>
+                        <a href="/topic/industrial_carb">Industrial Carbohydrates</a>
+                    </li>
+                    <li>
+                        <a href="/topic/industrial_org_chem">Industrial Organic Chemicals, Leather, Fats, and Waxes</a>
+                    </li>
+                    <li>
+                        <a href="/topic/polymer_phys">Physical Properties of Synthetic High Polymers</a>
+                    </li>
+                    <li>
+                        <a href="/topic/plastics_uses">Plastics Fabrication and Uses</a>
+                    </li>
+                    <li>
+                        <a href="/topic/plastics_manufacture">Plastics Manufacture and Processing</a>
+                    </li>
+                    <li>
+                        <a href="/topic/deterfents">Surface Active Agents and Detergents</a>
+                    </li>
+                    <li>
+                        <a href="/topic/elastomers_rubber">Synthetic Elastomers and Natural Rubber</a>
+                    </li>
+                    <li>
+                        <a href="/topic/textiles_fibers">Textiles and Fibers</a>
+                    </li>
+                </ul>
+            </div>
+        </li>
+
+        
+        <li class="category">
+            <a title="View this subject category" onclick="toggleSubjects($(this).parent());" href="JavaScript:void(0);"><span class="plusMinus">&nbsp;</span>
+                <span class="categoryTitle">Organic</span>
+            </a>
+            <div class="wrapper">
+                <ul>
+                    
+                    <li>
+                        <a href="/topic/alicyclic_compounds">Alicyclic Compounds</a>
+                    </li>
+                    <li>
+                        <a href="/topic/aliphatic_compounds">Aliphatic Compounds</a>
+                    </li>
+                    <li>
+                        <a href="/topic/alkaloids">Alkaloids</a>
+                    </li>
+                    <li>
+                        <a href="/topic/amino_acids">Amino Acids, Peptides, and Proteins</a>
+                    </li>
+                    <li>
+                        <a href="/topic/benzene">Benzene, Its Derivatives, and Condensed Benzenoid Compounds</a>
+                    </li>
+                    <li>
+                        <a href="/topic/biomolecules">Biomolecules and Their Synthetic Analogs</a>
+                    </li>
+                    <li>
+                        <a href="/topic/carbohydrates">Carbohydrates</a>
+                    </li>
+                    <li>
+                        <a href="/topic/general_organic">General Organic Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/heterocyclic_one">Heterocyclic Compounds (More than One Hetero Atom)</a>
+                    </li>
+                    <li>
+                        <a href="/topic/heterocyclic">Heterocyclic Compounds (One Hetero Atom)</a>
+                    </li>
+                    <li>
+                        <a href="/topic/organometallic">Organometallic and Organometalloidal Compounds</a>
+                    </li>
+                    <li>
+                        <a href="/topic/physical_organic">Physical Organic Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/steroids">Steroids</a>
+                    </li>
+                    <li>
+                        <a href="/topic/terpenes">Terpenes and Terpenoids</a>
+                    </li>
+                </ul>
+            </div>
+        </li>
+
+        
+        <li class="category">
+            <a title="View this subject category" onclick="toggleSubjects($(this).parent());" href="JavaScript:void(0);"><span class="plusMinus">&nbsp;</span>
+                <span class="categoryTitle">Physical, Inorganic, and Analytical</span>
+            </a>
+            <div class="wrapper">
+                <ul>
+                    
+                    <li>
+                        <a href="/topic/catalysis">Catalysis, Reaction Kinetics, and Inorganic Reaction Mechanisms</a>
+                    </li>
+                    <li>
+                        <a href="/topic/crystallography">Crystallography and Liquid Crystals</a>
+                    </li>
+                    <li>
+                        <a href="/topic/electric_phenomena">Electric Phenomena</a>
+                    </li>
+                    <li>
+                        <a href="/topic/electrochemistry">Electrochemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/gen_phys_chem">General Physical Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/inorganic_analytical">Inorganic Analytical Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/inorganic_chem">Inorganic Chemicals and Reactions</a>
+                    </li>
+                    <li>
+                        <a href="/topic/magnetic_phenomena">Magnetic Phenomena</a>
+                    </li>
+                    <li>
+                        <a href="/topic/nuclear_phenomena">Nuclear Phenomena</a>
+                    </li>
+                    <li>
+                        <a href="/topic/nuclear_technology">Nuclear Technology</a>
+                    </li>
+                    <li>
+                        <a href="/topic/spectroscopy">Optical, Electron, and Mass Spectroscopy and Other Related Properties</a>
+                    </li>
+                    <li>
+                        <a href="/topic/organic_analytical">Organic Analytical Chemistry</a>
+                    </li>
+                    <li>
+                        <a href="/topic/solutions">Phase Equilibriums, Chemical Equilibriums, and Solutions</a>
+                    </li>
+                    <li>
+                        <a href="/topic/reprographic">Radiation Chemistry, Photochemistry, and Photographic and Other Reprographic Processes</a>
+                    </li>
+                    <li>
+                        <a href="/topic/surface_chem">Surface Chemistry and Colloids</a>
+                    </li>
+                    <li>
+                        <a href="/topic/thermodynamics">Thermodynamics, Thermochemistry, and Thermal Properties</a>
+                    </li>
+                </ul>
+            </div>
+        </li>
+
+        
+    </ul>
+</div></div>
+        </div>
+    </div>
+    
+
+                            
+                        
+                    </div>
+                </div>
+            
+        
+    </div>
+
+    
+
+</div></div>
+        </div>
+    </div>
+    
+</div></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumInstitutionBanner none cobrandText widget-none  widget-compact-all" id="50ab07c6-00b5-4eac-9a23-cb64cfd91f9f"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="welcome">
+    
+    
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none  widget-compact-all" id="1cbb0a59-5205-40ed-82bc-877671a52f41"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="jFamNav">
+	<ul>
+		<li class="selected"><a href="JavaScript:void(0);"><cite>J. Med. Chem.</cite></a></li>
+		<li><a href="/journal/amclct"><cite>ACS Med. Chem. Lett.</cite></a></li>
+	</ul>
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none  widget-compact-all" id="b2fe694b-bba5-4e20-a4db-ff6197429fe4"  >
+        
+        
+            
+        
+
+        <div class="wrapped " id='series-navigation'>
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="menuXml seriesNav">
+	<ul class="primaryNav">
+		<li class="home">
+			<a href="/journal/jmcmar">
+				<span>Home</span>
+			</a>
+		</li>
+
+		<li>
+			<a class="expander" href="/loi/jmcmar">Browse the Journal</a>
+			<ul>
+				<li><a href="/loi/jmcmar">List of Issues</a></li>
+<li><a href="/toc/jmcmar/0/ja">Just Accepted Manuscripts</a></li>
+				<li><a href="/action/showMostReadArticles?journalCode=jmcmar">Most Read Articles</a></li>
+				<li><a href="/action/showAuthorIndex?journalCode=jmcmar">Author Index</a></li>
+				<li><a href="/action/showCoverGallery?journalCode=jmcmar">Cover Art Gallery</a></li>
+<li><a href="/page/virtual-collections.html?ref=jmcmarbrowse">Virtual Issues</a></li>
+			</ul>
+		</li>
+
+		<li>
+			<a href="/toc/jmcmar/0/0">Articles ASAP</a>
+		</li>
+
+		<li>
+			<a href="/toc/jmcmar/current">Current Issue</a>
+		</li>
+
+		<li>
+			<a class="expander" href="/page/jmcmar/submission/index.html">Submission &amp; Review</a>
+			<ul>
+				<li><a href="/page/jmcmar/submission/index.html">Information for Authors and Reviewers</a></li>
+				<li><a href="/paragonplus/submission/jmcmar/jmcmar_authguide.pdf">Author Guidelines [PDF]</a></li>
+				<li><a href="http://paragonplus.acs.org/login">Submit a Manuscript or Review</a></li>
+				<li><a href="/page/policy/ethics/index.html">Ethical Guidelines</a></li>
+				<li><a href="/page/copyright/index.html">Copyright &amp; Permissions/RightsLink</a></li>
+				<li><a href="/page/4authors/index.html">ACS Author &amp; Reviewer Resource Center</a></li>
+			</ul>
+		</li>
+
+		<li>
+			<a href="http://acsopenaccess.org">Open Access</a>
+		</li>
+
+		<li>
+			<a class="expander" href="/page/jmcmar/about.html">About the Journal</a>
+			<ul>
+				<li><a href="/page/jmcmar/about.html">About the Journal</a></li>
+				<li><a href="/page/jmcmar/profile.html">Editor Profile</a></li>
+<li><a href="/page/jmcmar/profile1.html">Editor Profile</a></li>
+				<li><a href="/page/jmcmar/editors.html">Editorial Board</a></li>
+				<li><a href="/pb-assets/documents/masthead/jmcmar-masthead.pdf">Masthead [PDF]</a></li>
+				<li><a href="/pb-assets/documents/eab/jmcmar-eab.pdf">Editorial Advisory Board [PDF]</a></li>
+				<li><a href="http://acsmediakit.org/">Advertising Media Kit</a></li>
+			</ul>
+		</li>
+    
+	</ul>      
+</div></div>
+        </div>
+    </div>
+    
+    </div>
+</header></div>
+        </div>
+    </div>
+    
+
+
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget pageBody none article-page widget-none  widget-compact-all" id="623dc177-ba39-4f83-83c5-cf9808be195f"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><!--begin pagefulltext-->
+<div class="page-body pagefulltext">
+    <div data-pb-dropzone="main">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+            
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-frame none  widget-regular  widget-border-toggle widget-compact-all" id="32798733-6699-4743-9ba0-bcb2ddfd5351"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-regular  body-border-toggle body-compact-all"><div data-pb-dropzone="contents">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-two-columns none article-type-and-nav widget-none  widget-compact-all" id="c19b0f7c-22ac-42b9-8bcf-dad150505eb2"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="pb-columns row-fluid gutterless">
+    <div class="width_1_2">
+        <div data-pb-dropzone="left" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget manuscriptType none  widget-none  widget-compact-all" id="da950b5f-ff19-4703-be7d-a15479a19082"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><h3 class="manuscriptType">Article</h3></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+    <div class="width_1_2">
+        <div data-pb-dropzone="right" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumBookIssueNavigation none  widget-none  widget-compact-all" id="6d0914e1-8b40-4071-9399-235e49d836e1"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="pager issueNavPageContainer">
+    
+        <div class="issueNavigator">
+            <div class="journalNavLeftTd">
+                
+                        
+                    
+            </div>
+            <div class="journalNavRightTd">
+                
+                        
+                            
+                            <div class="next">
+                                <a href="/doi/full/10.1021/acs.jmedchem.6b00523" title="Next Article">
+                                    Next Article
+                                </a>
+                            </div>
+                        
+                    
+
+            </div>
+        </div>
+    
+
+    
+        
+            <div class="journalNavCenterTd">
+                <span class="journalNavTitle">
+                    
+
+                    
+                            
+                                    <a href="/toc/jmcmar/0/0">Articles ASAP</a>
+                                
+                        
+                </span>
+
+                
+
+                
+                
+
+                
+
+                
+
+            </div>
+        
+    
+
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none  widget-compact-all" id="7efd1d6e-21a6-48c5-8b37-77cf7a915c9a"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><script type="text/javascript">
+$(function(){
+	$('.literatumBookIssueNavigation .BookNavCenterTd b').text('Table of Contents');
+});
+</script></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-two-columns none article-main-cols widget-none  widget-compact-all" id="6901cc5c-a7f6-4109-bf08-278038ba53a6"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="pb-columns row-fluid gutterless">
+    <div class="width_17_24">
+        <div data-pb-dropzone="left" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumPublicationContentWidget none  widget-none  widget-compact-all" id="d2a196f9-55e7-492a-9643-735a41b61a8c"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><script type="text/javascript">
+<!-- // hide it from old browsers
+
+var anyDbId = -1;
+var sideParts = {
+    citation: "<tr><td class=\"black9pt\" width=\"15\" valign=\"top\">&nbsp;&bull;&nbsp;<\/td><td class=\"black9pt\" valign=\"top\"><a href=\"javascript:newWindow('{$linkoutUrl}')\">{$display}<\/a><\/td><\/tr>",
+    citingIsi: "<tr><td class=\"black9pt\" width=\"15\" valign=\"top\">&nbsp;&bull;&nbsp;<\/td><td class=\"black9pt\" valign=\"top\">Search for citing articles in:<br/>&nbsp;<a href=\"javascript:newWindow('/servlet/linkout?suffix=s0&dbid=128&doi={$doi}&url={$urlEnc}')\">ISI Web of Science<\/a> ({$citNum} or more)<\/a><\/td><\/tr>",
+    citingCrossref: "<tr><td class=\"black9pt\" width=\"15\" valign=\"top\">&nbsp;&bull;&nbsp;<\/td><td class=\"black9pt\" valign=\"top\"><a href=\"{$url}\">Citing articles in CrossRef<\/a><\/td><\/tr>",
+    quicksearch: "<option value=\"{$value}\">{$display}<\/option>",
+    related: ", <a href=\"javascript:newWindow('{$linkoutUrl}')\">{$display}<\/a>"
+};
+
+function genSide(part, dbid, linkoutUrl, display, doi, url, citNum, value) {
+    if (dbid != anyDbId && (140737488355327 & dbid) == 0) return;
+    var content = sideParts[part];
+    if (linkoutUrl) { content = content.replace(/{\$linkoutUrl}/g, linkoutUrl); }
+    if (display) { content = content.replace(/{\$display}/g, display); }
+    if (doi) { content = content.replace(/{\$doi}/g, doi); }
+    if (url) {
+        content = content.replace(/{\$url}/g, url);
+        content = content.replace(/{\$urlEnc}/g, encodeURIComponent(encodeURIComponent(url)));
+    }
+    if (citNum) { content = content.replace(/{\$citNum}/g, citNum); }
+    if (value) { content = content.replace(/{\$value}/g, value); }
+    document.write(content);
+}
+
+function hasSfxLinks() {
+	return false;
+}
+
+
+function genSfxLinks(id, url, doi) {
+    if (! doi) { doi = ""; }
+
+}
+function popSfxLink(prefix, id, url, doi) {
+    if (doi) {
+        url += "&id=doi:"+doi;
+    } else {
+        doi = "10.1021%2Facs.jmedchem.6b00723";
+    }
+    var redirect = prefix + encodeURIComponent("?sid=achs&genre=article"+url);
+    var href = "/servlet/linkout?suffix="+id+"&dbid=16384&doi="+doi+"&url=" + encodeURIComponent(redirect);
+    return newWindow(href);
+}
+
+var sfxRefDisplay = {
+64:"ADS",
+32:"CAS",
+8192:"CIS",
+256:"CSA",
+16:"CrossRef",
+128:"ISI",
+4096:"JSTOR",
+8:"PubMed",
+1099511627776: "Ichushi",
+17592186044416: "Medical Online",
+8796093022208: "J-Stage",
+2199023255552: "Medical Finder",
+4398046511104: "Pier Online"
+};
+
+window.onload=disableRefLinkWrite ;
+
+function genRefLink(dbid, id, key, textOfLink) {
+    if (140737488355327 & dbid != 0) {
+        if (typeof textOfLink === "undefined") {
+            if (sfxRefDisplay[dbid].substring(0,1) == "[") {
+                textOfLink = sfxRefDisplay[dbid];
+            } else {
+                textOfLink = "["+sfxRefDisplay[dbid]+"]";
+            }
+            // ToDo: move '[' and ']' to sfxRefDisplay (UPDATE: finish changing sfxRefDisplays and remove this branch)
+        }
+        else{ textOfLink = unescape(textOfLink)};
+
+        if(document.disableRefLinkWrite == null){
+            document.write("<a class='ref' href=\"javascript:popRefLink("+dbid+",'"+id+"','"+key+"')\">"+textOfLink+"<\/a>");
+        }
+    }
+}
+
+function disableRefLinkWrite () {
+    document.disableRefLinkWrite = true;
+}
+
+function popRefLink(dbid, id, key) {
+    var redirect = "/servlet/linkout?suffix=" + id + "&dbid=" + dbid + "&doi=10.1021%2Facs.jmedchem.6b00723&key=" + key;
+    return newWindow(redirect);
+}
+function popRefFull(rid, citart, ptype, area) {
+    return popRefImplFull(rid, citart, ptype, area, 600, 500);
+}
+function popRefImplFull(rid, citart, ptype, area, width, height) {
+    var doi = "10.1021%2Facs.jmedchem.6b00723";
+    if (! ptype) { ptype = ""; }
+    var pt = rid.charAt(0) + "acsjmedchem6b00723" + ptype;
+    return popupFull(rid, doi, pt, area, width, height);
+}
+function popRef(rid, citart, ptype, area) {
+    return popRefImpl(rid, citart, ptype, area, 600, 500);
+}
+function popRef2(rid, citart, ptype, area) {
+    return popRefImpl(rid, citart, ptype, area, 400, 100);
+}
+function popRefImpl(rid, citart, ptype, area, width, height) {
+    var doi = "10.1021%2Facs.jmedchem.6b00723";
+    if (! citart) { citart = "citart1"; }
+    if (! ptype) { ptype = ""; }
+    var pt = rid.charAt(0) + "acsjmedchem6b00723" + ptype;
+    return popupRef(citart, rid, doi, pt, area, width, height);
+}
+
+
+
+function genCitingCrossref() {
+}
+
+var tollFreeLinking = new Object();
+
+var citLinkDisplay = {
+    
+    0:"SYSTEM",
+4:"SYSTEM",
+20:"SYSTEM",
+64:"ADS",
+32:"CAS",
+8192:"CIS",
+256:"CSA",
+16:"CrossRef",
+128:"ISI",
+4096:"JSTOR",
+8:"MEDLINE"
+};
+var feeBasedMask = 4480;
+
+function genCitLink(dbid, suffix, key) {
+    if (dbid != anyDbId && (feeBasedMask & dbid) != 0 && (140737488355327 & dbid) == 0) return;
+
+    var param = "/servlet/linkout?suffix=" + suffix + "&dbid=" + dbid + "&doi=10.1021%2Facs.jmedchem.6b00723&key=" + key;
+    var display = citLinkDisplay[dbid];
+    var img = "/templates/jsp/_style2/_achs/images/" + display + "_btn.gif";
+
+
+    if((typeof tollFreeLinking) != "undefined" && tollFreeLinking[key])
+    {
+        param = param + "&tollfreelink=" + tollFreeLinking[key];
+    }
+
+
+    document.write("<a class='ref' href='javascript:newWindow(\"" + param + "\")'>");
+    document.write("<" + "img src='"+img+"' width='85' height='20' align='BOTTOM' alt='"+display+" Abstract' border='0'/>");
+    document.write("<\/a>");
+}
+// stop hiding -->
+</script>
+<script type="text/javascript" src="/swfobject.js"></script>
+<script type="text/javascript">
+function addFlashMovie(id, flv) {
+    var flashvars = {file: flv ,type: 'flv'};
+    var params = {allowfullscreen :true};
+    var attributes = {};
+    swfobject.embedSWF('/flvplayer.swf', id, "352", "288", "7.0.0", false, flashvars, params, attributes);
+}
+
+function addFlashMovie(id, flv, image) {
+    var flashvars = {file: flv ,type: 'flv', image: image};
+    var params = {allowfullscreen :true};
+    var attributes = {};
+    swfobject.embedSWF('/flvplayer.swf', id, "352", "288", "7.0.0", false, flashvars, params, attributes);
+}
+</script>
+
+    <script type="text/javascript" async defer src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+
+    <div class="publication-tabs ja">
+    
+
+
+
+
+
+
+
+
+    
+        
+    
+
+
+<div class="tabs tabs-widget">
+    
+        
+        
+            
+    <script type="text/javascript">
+        initFigshare('https://widgets.figshare.com/static/figshare.js', '10.1021/acs.jmedchem.6b00723');
+    </script>
+
+        
+        <div class="tab-content ">
+            <div class="tab tab-pane active">
+                
+                        <article class="article">
+                                <h1 class="articleTitle"><span class="hlFld-Title">Discovery of a Quinoline-4-carboxamide Derivative with a Novel Mechanism of Action, Multistage Antimalarial Activity, and Potent in Vivo Efficacy</span></h1><div id="articleMeta"><div id="authors"><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Baraga%C3%B1a%2C+Beatriz">Beatriz Baragaña</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Norcross%2C+Neil+R">Neil R. Norcross</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Wilson%2C+Caroline">Caroline Wilson</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Porzelle%2C+Achim">Achim Porzelle</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Hallyburton%2C+Irene">Irene Hallyburton</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Grimaldi%2C+Raffaella">Raffaella Grimaldi</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Osuna-Cabello%2C+Maria">Maria Osuna-Cabello</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Norval%2C+Suzanne">Suzanne Norval</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Riley%2C+Jennifer">Jennifer Riley</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Stojanovski%2C+Laste">Laste Stojanovski</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Simeons%2C+Frederick+R+C">Frederick R. C. Simeons</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Wyatt%2C+Paul+G">Paul G. Wyatt</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Delves%2C+Michael+J">Michael J. Delves</a></span><span><span class="NLM_xref-aff"><sup>‡</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Meister%2C+Stephan">Stephan Meister</a></span><span><span class="NLM_xref-aff"><sup>§</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Duffy%2C+Sandra">Sandra Duffy</a></span><span><span class="NLM_xref-aff"><sup>∥</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Avery%2C+Vicky+M">Vicky M. Avery</a></span><span><span class="NLM_xref-aff"><sup>∥</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Winzeler%2C+Elizabeth+A">Elizabeth A. Winzeler</a></span><span><span class="NLM_xref-aff"><sup>§</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Sinden%2C+Robert+E">Robert E. Sinden</a></span><span><span class="NLM_xref-aff"><sup>‡</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Wittlin%2C+Sergio">Sergio Wittlin</a></span><span><span class="NLM_xref-aff"><sup>⊥</sup></span></span><span><span class="NLM_xref-aff"><sup>#</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Frearson%2C+Julie+A">Julie A. Frearson</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Gray%2C+David+W">David W. Gray</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Fairlamb%2C+Alan+H">Alan H. Fairlamb</a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Waterson%2C+David">David Waterson</a></span><span><span class="NLM_xref-aff"><sup>∇</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Campbell%2C+Simon+F">Simon F. Campbell</a></span><span><span class="NLM_xref-aff"><sup>∇</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Willis%2C+Paul">Paul Willis</a></span><span><span class="NLM_xref-aff"><sup>∇</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Read%2C+Kevin+D">Kevin D. Read</a></span><span><a class="ref" href="#cor1"><sup>*</sup></a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, and </x></span></span></span><span class="hlFld-ContribAuthor"><span class="hlFld-ContribAuthor"><a id="authors" href="/author/Gilbert%2C+Ian+H">Ian H. Gilbert</a></span><span><a class="ref" href="#cor2"><sup>*</sup></a></span><span><span class="NLM_xref-aff"><sup>†</sup></span></span><span><span class="NLM_x"> </span></span></span></div><div class="affiliations"><div id="aff1"><sup>†</sup> Drug
+Discovery Unit, Division of Biological Chemistry and Drug Discovery,
+School of Life Sciences, <span class="institution">University of Dundee</span>, Dundee, DD1 5EH, <span class="country">U.K.</span></div><div id="aff2"><sup>‡</sup> Cell
+and Molecular Biology, Department of Life Sciences, <span class="institution">Imperial College</span>, London, SW7 2AZ, <span class="country">U.K.</span></div><div id="aff3"><sup>§</sup> School
+of Medicine, <span class="institution">University of California, San
+Diego</span>, 9500 Gilman Drive, La Jolla, California 92093, <span class="country">United States</span></div><div id="aff4"><sup>∥</sup> Eskitis
+Institute, <span class="institution">Griffith University</span>, Brisbane Innovation Park, Nathan
+Campus, Brisbane, QLD 4111, <span class="country">Australia</span></div><div id="aff5"><sup>⊥</sup> Swiss Tropical
+and Public Health Institute, Swiss TPH, Socinstrasse 57, 4051 Basel, <span class="country">Switzerland</span></div><div id="aff5.1"><sup>#</sup> <span class="institution">University
+of Basel</span>, CH-4003 Basel, <span class="country">Switzerland</span></div><div id="aff6"><sup>∇</sup> <span class="institution">Medicines
+for Malaria Venture</span>, International Centre Cointrin, Entrance G, 3rd Floor, Route de Pré-Bois
+20, P.O. Box 1826, CH-1215, Geneva 15, <span class="country">Switzerland</span></div></div><div id="citation"><cite>J. Med. Chem.</cite>, Article ASAP</div><div id="doi"><strong>DOI: </strong>10.1021/acs.jmedchem.6b00723</div><div id="pubDate">Publication Date (Web): September 10, 2016</div><div id="artCopyright">Copyright © 2016 American Chemical Society</div><div id="correspondence">*K.D.R.: phone, <span class="phone">+44 1382 388 688</span>; e-mail, <a href="mailto:k.read@dundee.ac.uk">k.read@dundee.ac.uk</a>., *I.H.G.: phone, <span class="phone">+44 1382 386 240</span>; e-mail, <a href="mailto:i.h.gilbert@dundee.ac.uk">i.h.gilbert@dundee.ac.uk</a>.</div><div class="icon-item editors-choice"><a href="http://pubs.acs.org/page/policy/editorchoice/index.html" title="Learn more about ACS Editors’ Choice"><div class="icon-24px"></div></a>
+                        ACS Editors' Choice - This is an open access article published under a Creative Commons Attribution (CC-BY) <a class="textDecorationNone" href="http://pubs.acs.org/page/policy/authorchoice_ccby_termsofuse.html">License</a>, which permits unrestricted use, distribution and reproduction in any medium, provided the author and source are cited.</div></div><div id="articleBody"><div class="hlFld-Abstract"><ul class="anchors"><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="Abstract">Abstract</h2><div id="abstractBox"><div class="figure" id="f_null"><a title="Open Figure Viewer" href="#" class="showFiguresEvent" id="absImg"><img alt="Abstract Image" src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0017.gif" /><span class="overlay"></span></a></div><p class="articleBody_abstractText">The antiplasmodial activity, DMPK properties, and efficacy of a series of quinoline-4-carboxamides are described. This series was identified from a phenotypic screen against the blood stage of <i>Plasmodium falciparum</i> (3D7) and displayed moderate potency but with suboptimal physicochemical properties and poor microsomal stability. The screening hit (<b>1</b>, EC<sub>50</sub> = 120 nM) was optimized to lead molecules with low nanomolar in vitro potency. Improvement of the pharmacokinetic profile led to several compounds showing excellent oral efficacy in the <i>P. berghei</i> malaria mouse model with ED<sub>90</sub> values below 1 mg/kg when dosed orally for 4 days. The favorable potency, selectivity, DMPK properties, and efficacy coupled with a novel mechanism of action, inhibition of translation elongation factor 2 (<i>Pf</i>EF2), led to progression of <b>2</b> (DDD107498) to preclinical development.</p></div></div><div class="hlFld-Fulltext"><div id="sec1" class="NLM_sec NLM_sec_level_1"><ul class="anchors"><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="_i2">Introduction</h2><hr /><div class="NLM_p">Malaria is a devastating disease with over 214 million clinical cases in 2015.<a onclick="showRef(event, 'ref1'); return false;" href="JavaScript:void(0);" class="ref">(1)</a> In that year alone, the World Health Organization (WHO) estimated 438 000 deaths, mostly among children under five in Sub-Saharan Africa. The current malaria control programs that combine preventive measures with artemisinin combination therapy (ACT) treatment have proven very effective in reducing the malaria burden. Over the past decade, the number of deaths from malaria has fallen by 4% per year, and between 2000 and 2015 the number of clinical cases of malaria has been estimated to have decreased by 40% where the disease is endemic in Africa.<a onclick="showRef(event, 'ref2'); return false;" href="JavaScript:void(0);" class="ref">(2)</a> However, in recent years, parasite resistance to artemisinin has been detected in a number of countries in Southeast Asia. For example, in areas along the Cambodia–Thailand border, <i>Plasmodium falciparum</i>, the most deadly malaria parasite, has become resistant to most available antimalarial medicines and the spread of multidrug resistance is a major concern.<a onclick="showRef(event, 'ref3'); return false;" href="JavaScript:void(0);" class="ref">(3)</a></div><div class="NLM_p">The malaria drug discovery portfolio has dramatically improved over the past 10 years.<a onclick="showRef(event, 'ref4'); return false;" href="JavaScript:void(0);" class="ref">(4)</a> However, due to the constant battle against drug resistance and to achieve malaria elimination, new chemotypes with novel mechanisms of action are required. New drugs are needed: (1) that are not cross-resistant to existing drugs; (2) that can be given as a single dose; (3) that prevent transmission (active against the sexual stages of the parasite); (4) that can give chemoprotection (active against liver stages). Recently, we reported the discovery and profile of <b>2</b> (DDD107498),<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> a quinoline-4-carboxamide with excellent pharmacokinetic and antimalarial properties, including activity against multiple life-cycle stages of the parasite. Moreover, this compound acts through a novel mechanism of action for antimalarial chemotherapy, inhibition of translation elongation factor 2 (<i>Pf</i>EF2), which is critical for protein synthesis.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> In this paper we describe the medicinal chemistry program that led to the discovery of <b>2</b>.</div><div class="NLM_p">The quinoline-4-carboxamide series was identified from a phenotypic screen of the Dundee protein kinase library<a onclick="showRef(event, 'ref6'); return false;" href="JavaScript:void(0);" class="ref">(6)</a> against the blood stage of the <i>P. falciparum</i> 3D7 strain. The most active compound of the original hit series displayed good activity in vitro against a chloroquine sensitive <i>P. falciparum</i> strain (3D7) and good selectivity index (&gt;100-fold) against a human cell line (MRC-5). However, hit compound <b>1</b> had a high clogP and poor aqueous solubility and was metabolically unstable with a high hepatic microsomal intrinsic clearance (Cli). (<a class="ref" href="#fig1">Figure <a class="ref" href="#fig1">1</a></a> and <a class="ref" href="#tbl1">Table <a class="ref" href="#tbl1">1</a></a>).</div><div class="figure" id="fig1"><a title="Open Figure Viewer" href="#" class="thumbnail showFiguresEvent"><img alt="figure" src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/small/jm-2016-00723u_0002.gif" /><span class="overlay"></span></a><div class="caption hlFld-FigureCaption"><p class="first last">Figure 1. Key data for screening hit <b>1</b> and preclinical candidate <b>2</b>. Data reported previously.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div></div><div class="NLM_table-wrap" id="tbl1"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 1. Optimization the R<sup>1</sup> and R<sup>2</sup> Moieties</div></div></div><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0007.gif" alt="" /><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0008.gif" alt="" /><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t1fn1">Table a<p class="last">MLM: mouse liver microsomes.</p></div><div class="footnote" id="t1fn2">Table b<p class="last">Sol: kinetic aqueous solubility. Data for compounds <b>1</b>, <b>11</b>, and <b>19</b> reported previously.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div></div></div></div><div id="sec2" class="NLM_sec NLM_sec_level_1"><ul class="anchors"><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="_i4">Results and Discussion</h2><hr /><div class="NLM_p">The initial aim of the hit to lead program was to improve potency (<i>Pf</i> EC<sub>50</sub>(3D7) &lt; 0.1 μM), aqueous solubility (&gt;100 μM), and metabolic stability (mouse liver microsomes Cli &lt; 5 mL min<sup>–1</sup> g<sup>–1</sup>) of compound <b>1</b>. Iterative rounds of drug design, synthesis, and biological evaluation were driven by the Medicines for Malaria Venture (MMV) compound progression criteria.<a onclick="showRef(event, 'ref7'); return false;" href="JavaScript:void(0);" class="ref">(7)</a> Initial modifications were directed toward improving the physicochemical properties particularly reducing lipophilicity. The clogP of the hit was 4.3, which is higher than average for oral drugs and may contribute to the poor aqueous solubility and hepatic microsomal instability.<a onclick="showRef(event, 'ref8'); return false;" href="JavaScript:void(0);" class="ref">(8)</a> Several points for modification on the scaffold were identified that could address the high lipophilicity: the bromine atom (R<sup>1</sup>) significantly adds to lipophilicity, as do aromatic substituents in the carboxamide (R<sup>2</sup>) and quinoline (R<sup>3</sup>) moieties. High numbers of aromatic rings are associated with unfavorable lipophilicity and poor compound developability.<a onclick="showRef(event, 'ref9'); return false;" href="JavaScript:void(0);" class="ref">(9)</a></div><div class="NLM_p">The initial focus was on the R<sup>1</sup> and R<sup>2</sup> substituents. Quinoline-4-carboxamides <b>10</b>–<b>19</b> were prepared in two steps from the corresponding isatin (<a class="ref" href="#sch1">Scheme <a class="ref" href="#sch1">1</a></a>), employing the Pfitzinger reaction with 1-(<i>p</i>-tolyl)ethanone using potassium hydroxide as a base in a mixture of ethanol and water at 125 °C under microwave irradiation to afford the quinoline-4-carboxylic acid <b>3</b>.<a onclick="showRef(event, 'ref10'); return false;" href="JavaScript:void(0);" class="ref">(10)</a> Coupling of <b>3</b> with the corresponding amine, using EDC and HOBt in DMF, led to compounds <b>10</b>–<b>19</b> (<a class="ref" href="#sch1">Scheme <a class="ref" href="#sch1">1</a></a>).</div><div class="figure" id="sch1"><a title="Open Figure Viewer" href="#" class="thumbnail showFiguresEvent"><img alt="figure" src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/small/jm-2016-00723u_0004.gif" /><span class="overlay"></span></a><div class="caption hlFld-FigureCaption"><p class="first last">Scheme 1. <sup>a</sup></p></div><p class="last"><p class="last"><sup>a</sup>Conditions: (a) KOH, EtOH/water, 125 °C, microwave, 20 min, 29–58% yield; (b) amine, EDC, HOBt, DMF, room temperature, 16 h, 22–43% yield.</p></p></div><div class="NLM_p">Replacement of the bromine moiety at R<sup>1</sup> with chlorine (<b>10</b>) or fluorine (<b>11</b>)<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> was tolerated without significant loss of activity while decreasing molecular weight and clogP (<a class="ref" href="#tbl1">Table <a class="ref" href="#tbl1">1</a></a>). However, removal of the halogen altogether in compound <b>12</b> led to an 8-fold drop in potency. Although fluorinated compound <b>11</b> was less lipophilic than initial hit <b>1</b>, it still showed poor solubility and metabolic stability.</div><div class="NLM_p">On the basis of these results, we next turned to the R<sup>2</sup> position with the aim of reducing the number of aromatic rings. A range of nonaromatic amines able to duplicate the hydrogen bonding potential of the 3-pyridyl moiety were evaluated. Results demonstrated that basicity, lipophilicity, and linker length were all important for activity (<a class="ref" href="#tbl1">Table <a class="ref" href="#tbl1">1</a></a>). Compounds (<b>17</b>, <b>18</b>, and <b>19</b>) with an ethyl linked piperidine or pyrrolidine retained similar activities to the corresponding 3-pyridyl derivatives. The replacement of the cyclic amine for a dimethylamine (<b>13</b>) and the introduction of longer linker lengths (<b>14</b>) led to drop in potency. Compounds <b>18</b> and <b>19</b><a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> showed enhanced hepatic microsomal stability and improved solubility. Furthermore, ligand-lipophilicity efficiency (LLE or LiPE)<a onclick="showRef(event, 'ref11'); return false;" href="JavaScript:void(0);" class="ref">(11)</a> improved for compound <b>19</b> (LLE = 3.2) compared with the initial hit <b>1</b> (LLE = 2.6). Subsequent analogues were optimized using the ethyl linked pyrrolidine substituent on the amide at R<sup>2</sup>, which displayed the best profile in terms of lipophilicity, activity, and hepatic microsomal stability.</div><div class="NLM_p">After initial optimization of the R<sup>1</sup> and R<sup>2</sup> groups, we then turned our attention to the R<sup>3</sup> substituent with the aim of improving potency while maintaining lipophilicity at a moderate level (clogP &lt; 3.5). An efficient synthetic route (<a class="ref" href="#sch2">Scheme <a class="ref" href="#sch2">2</a></a>) was designed for rapid access to a variety of R<sup>3</sup> analogues which involved reaction of 5-fluoroisatin or 5-chloroisatin with malonic acid in refluxing acetic acid to provide intermediate <b>4</b>.<a onclick="showRef(event, 'ref12'); return false;" href="JavaScript:void(0);" class="ref">(12)</a> A one pot chlorination and amide formation was achieved by treating 2-hydroxyquinoline-4-carboxylic acid <b>4</b> with thionyl chloride in the presence of DMF followed by reaction of the intermediate acid chloride with 2-pyrrolidin-1-ylethanamine in THF at room temperature. Intermediate <b>5</b> underwent aromatic nucleophilic substitution with a range of amines under microwave irradiation in acetonitrile to afford compounds <b>21</b>–<b>30</b> (<a class="ref" href="#tbl2">Table <a class="ref" href="#tbl2">2</a></a>). This route was also used for the synthesis of derivatives with aromatic R<sup>3</sup> substituents where a Suzuki coupling of intermediate <b>5</b> with the appropriate boronic acid or ester led to compounds <b>36</b>–<b>39</b>.</div><div class="figure" id="sch2"><a title="Open Figure Viewer" href="#" class="thumbnail showFiguresEvent"><img alt="figure" src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/small/jm-2016-00723u_0005.gif" /><span class="overlay"></span></a><div class="caption hlFld-FigureCaption"><p class="first last">Scheme 2. <sup>a</sup></p></div><p class="last"><p class="last"><sup>a</sup>Conditions: (a) malonic acid, acetic acid, reflux, 16 h, 54%; (b) SOCl<sub>2</sub>, DMF, DCM, reflux, 3 h and then 2-pyrrolidin-1-ylethanamine, THF, room temperature, 16 h, 27–43% yield; (c) amine, acetonitrile, 170 °C, microwave, 1 h, 7–54% yield; (d) boronic acid or ester, potassium phosphate, Pd(PPh<sub>3</sub>)<sub>4</sub>, DMF/water 3/1, 130 °C, microwave, 30 min, 19–73%.</p></p></div><div class="NLM_table-wrap" id="tbl2"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 2. SAR Study of the R<sup>3</sup> Substituent: Amines</div></div></div><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0009.gif" alt="" /><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0010.gif" alt="" /><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t2fn1">Table a<p class="last">MLM: mouse liver microsomes.</p></div><div class="footnote" id="t2fn2">Table b<p class="last">Kinetic aqueous solubility.</p></div></div></div><div class="NLM_p">In general, the replacement of the tolyl substituent by an array of primary and secondary amines drove lipophilicity down and also led to improved solubility and hepatic microsomal stability (<a class="ref" href="#tbl2">Table <a class="ref" href="#tbl2">2</a></a>). In terms of potency, small heterocyles like 4-amino-3-methyloxazole <b>20</b> and <i>N</i>-methylpiperazine <b>21</b> at the R<sup>3</sup> position were not tolerated. However, introduction of the 4-morpholinopiperidine <b>24</b> (EC<sub>50</sub> = 0.15 μM, LLE = 4.2) moiety improved both potency and ligand efficiency compared with previous lead compound <b>18</b>. Compound <b>24</b> displayed good aqueous solubility and moderate mouse hepatic microsomal clearance, which is probably related to the reduction in lipophilicity (clogP = 2.9).</div><div class="NLM_p">To improve the potency of compound <b>24</b>, we investigated other aliphatic amines. The introduction of flexibility at R<sup>3</sup> with an aminopropyl morpholine substituent (<b>25)</b> led to a further improvement in potency against <i>P. falciparum</i> (EC<sub>50</sub> = 70 nM) and lipophilic ligand efficiency (LLE = 5.4), with excellent selectivity against mammalian cells. Compound <b>25</b> had good aqueous solubility and in vitro hepatic microsomal stability across a range of species (Cli (mL min<sup>–1</sup> g<sup>–1</sup>): mouse 0.8; rat &lt;0.5; human &lt;0.5) and low plasma protein binding (59%). The good in vitro DMPK properties of compound <b>25</b> translated into reasonable in vivo pharmacokinetics in mouse (<a class="ref" href="#tbl7">Table <a class="ref" href="#tbl7">7</a></a>). Furthermore, compound <b>25</b> afforded oral in vivo activity (<a class="ref" href="#tbl8">Table <a class="ref" href="#tbl8">8</a></a>) in the <i>P. berghei</i> mouse model, with a 93% reduction of parasitemia when dosed orally at 30 mg/kg once a day for four consecutive days. An in vivo pharmacokinetic study in mice for compound <b>25</b> showed low clearance, with a moderate volume of distribution and a resultant good half-life. However, oral bioavailability was poor (<i>F</i> = 15%). The low systemic exposure of compound <b>25</b> was not attributed to high first-pass metabolism due to the low in vitro clearance in mouse microsomes and low in vivo blood clearance but was probably due to poor permeability as highlighted by results in a PAMPA assay (<a class="ref" href="#tbl6">Table <a class="ref" href="#tbl6">6</a></a>). Preliminary safety profiling of compound <b>25</b> showed a weak affinity to the hERG ion channel (16% inhibition at 11 μM) and an oral maximum tolerated dose (MTD) greater than 300 mg/kg b.i.d. for 4 days. With an attractive overall profile, compound <b>25</b> was identified as a key molecule to declare early lead status for this series, according to the MMV compound development criteria.<a onclick="showRef(event, 'ref7'); return false;" href="JavaScript:void(0);" class="ref">(7)</a></div><div class="NLM_p">Moving into lead optimization, our focus was to improve potency, permeability, and bioavailability through structural modifications while retaining good physicochemical properties. Reducing the flexibility of compound <b>25</b> by shortening the linker length of the aminoalkylmorpholine moiety at R<sup>3</sup> was tolerated (<b>26</b>). More promising was the 17-fold improvement (EC<sub>50</sub> = 4 nM) on antiplasmodial activity obtained when the linker was extended from three to four carbons (<b>27</b>). Compound <b>27</b> displayed excellent lipophilic ligand efficiency (LLE = 6.2). This improvement on in vitro potency led to enhanced in vivo efficacy (<a class="ref" href="#tbl8">Table <a class="ref" href="#tbl8">8</a></a>) with an ED<sub>90</sub> of 2.6 mg/kg. In addition with compound <b>27</b>, one out of three mice went to cure at 4 × 30 mg/kg (q.d. po). Mouse in vivo pharmacokinetics showed a longer half-life than the early lead <b>25</b> as a result of lower in vivo clearance and a slightly higher volume of distribution (<a class="ref" href="#tbl7">Table <a class="ref" href="#tbl7">7</a></a>). Despite having improved in vivo potency and half-life, oral bioavailability was still poor, presumably still due to poor permeability (PAMPA <i>P</i><sub>e</sub> = 2 nm/s).</div><div class="NLM_p">Modifications of our lead compound (<b>25</b>) focused on modulation of basicity, with the aim of improving permeability. Specifically, we envisaged that lowering basicity would reduce protonation at physiological pH, increase passive permeability, and ultimately improve bioavailability. Early lead <b>25</b> has two basic groups, a pyrrolidine (R<sup>2</sup>) and a morpholine (R<sup>3</sup>) with calculated p<i>K</i><sub>a</sub> values of 8.5 and 7.0 respectively. We first investigated the effect that modifications on the morpholine group at R<sup>3</sup> had on in vitro activity and permeability. We found that the morpholine oxygen was crucial for antiparasitic activity and replacement of the morpholino group by piperidine (<b>28)</b> was not tolerated. In contrast, the morpholine nitrogen was not essential for potency and removal, as exemplified by compounds <b>29</b> and <b>30</b>, was well tolerated leading to single digit nanomolar potency against <i>P. falciparum.</i> Moreover, the removal of the basic group at R<sup>3</sup> had not only improved activity but increased permeability more than 20-fold (<b>30</b>, <i>P</i><sub>e</sub> = 48 nm/s). Furthermore, improved in vitro permeability also translated in vivo, with an increase in oral bioavailability in mice (<i>F</i> = 23%). Despite its shorter half-life, compound <b>30</b> was efficacious in the <i>P. berghei</i> mouse model with an ED<sub>90</sub> of 1 mg/kg and achieved a level of in vivo efficacy that met the MMV late lead criteria. However, compound <b>30</b> showed very poor rat in vivo exposure that was explained by high intrinsic clearance in rat hepatocytes (Cli = 3 mL min<sup>–1</sup> g<sup>–1</sup>) which was subsequently confirmed by high hepatic extraction (76%) in a rat hepatic portal vein study. As for other compounds in this series, in vitro hepatic microsomal clearance was consistently low across species (<a class="ref" href="#tbl6">Table <a class="ref" href="#tbl6">6</a></a>).</div><div class="NLM_p">After establishing a link between basicity, PAMPA permeability, and oral bioavailability for the series, we focused on modulating the p<i>K</i><sub>a</sub> of the pyrrolidine group, the stronger of the two basic groups on early lead <b>25</b>. Taking into account previous SAR showing that basicity and linker length were important for activity, we designed a short array of analogues with decreasing basicity.<a onclick="showRef(event, 'ref13'); return false;" href="JavaScript:void(0);" class="ref">(13)</a> Predicted p<i>K</i><sub>a</sub> ranged from 5.0 for 3-difluoropyrrolidine <b>35</b> to 7.9 for 4-fluoropiperidine <b>31</b> compared with a predicted p<i>K</i><sub>a</sub> of 8.5 for the lead pyrrolidine <b>25</b> (<a class="ref" href="#tbl3">Table <a class="ref" href="#tbl3">3</a></a>). As expected, a reduction of basicity resulted in up to 50-fold improvement in permeability. However, potency was dramatically reduced, highlighting the importance of the basic pyrrolidine nitrogen at the R<sup>2</sup> position.</div><div class="NLM_table-wrap" id="tbl3"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 3. Modulating Basicity of the Amide Substituent</div></div></div><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0011.gif" alt="" /><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0012.gif" alt="" /><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t3fn1">Table a<p class="last">Calculated p<i>K</i><sub>a</sub> using ChemAxon software.</p></div><div class="footnote" id="t3fn2">Table b<p class="last">Controls: atenolol, 0.7 nm/s; propanolol, 159 nm/s.</p></div></div></div><div class="NLM_p">Our attention then turned back to the R<sup>3</sup> position, with the aim of further improving permeability and bioavailability across species. Previous SAR had shown that a methyl group at the para position of an aromatic ring at C-2 was tolerated, so we therefore expanded the range of substituents to include larger groups while maintaining moderate lipophilicity. This strategy also had the advantage of reducing the number of H-bond donors and molecular flexibility, two key factors that can modulate permeability. Early examples of substitution at R<sup>3</sup> showed that introduction of amines, such as dimethylamine (<b>36</b>) and morpholine (<b>37</b>), reduced lipophilicity and was tolerated in terms of potency compared to compounds <b>11</b> and <b>19</b> (<a class="ref" href="#tbl4">Table <a class="ref" href="#tbl4">4</a></a>). Taking into account the leap in potency observed for <b>25</b> with a morpholine attached through a flexible linker at C-2, we prepared compound <b>2</b> with a carbon spacer between the phenyl ring and the morpholine to allow improved rotation. The introduction of the benzyl morpholine at R<sup>3</sup> (compound <b>2</b>) resulted in a 70-fold increase in potency against <i>Pf</i> (3D7) (EC<sub>50</sub> = 1 nM) while retaining good ligand efficiency (LLE = 5.9), more than 30 fold increase in permeability (PAMPA <i>P</i><sub>e</sub> = 73 nm/s) and excellent bioavailability in mice (<i>F</i> = 74%). Furthermore, in vivo efficacy studies with compound <b>2</b> demonstrated complete cure at 4 × 30 mg/kg po q.d. in a <i>P. berghei</i> mouse model, with an ED<sub>90</sub> of 0.1–0.3 mg/kg (<a class="ref" href="#tbl8">Table <a class="ref" href="#tbl8">8</a></a>).</div><div class="NLM_table-wrap" id="tbl4"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 4. SAR Study of the R<sup>3</sup> Substituent: Aromatic Groups</div></div></div><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0013.gif" alt="" /><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0014.gif" alt="" /><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t4fn1">Table a<p class="last">Calculated p<i>K</i><sub>a</sub> using ChemAxon software. Experimental p<i>K</i><sub>a</sub> using potentiometric titration is shown in parentheses.</p></div><div class="footnote" id="t4fn2">Table b<p class="last">Data for this compound reported previously.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div></div></div><div class="NLM_p">We developed short, four-step synthetic routes for synthesis of <b>2</b> and <b>42</b> which did not involve the use of palladium catalysis (<a class="ref" href="#sch3">Scheme <a class="ref" href="#sch3">3</a></a>). Two approaches were employed to synthesize the methyl ketone <b>8</b> depending on the availability of commercial starting materials. In the first route, nucleophilic displacement of commercially available 4-(bromomethyl)benzonitrile with morpholine using trimethylamine as a base in DCM gave intermediate <b>6</b> which was then converted into the desired methyl ketone <b>8</b> by reaction with methylmagnesium bromide followed by an acidic quench. In the second route, radical bromination of commercially available 1-(2-chloro-4-methylphenyl)ethanone with NBS using catalytic amounts of benzoyl peroxide in dichlorobenzene afforded compound <b>7</b>, which was subsequently reacted with morpholine to yield the methyl ketone <b>8</b>. As described earlier, a Pfitzinger reaction of 5-fluoroisatin with the appropriate methyl ketone led to acid <b>9</b>. The final amides were prepared using 2-chloro-4,6-dimethoxy-1,3,5-triazine (CDMT) as coupling agent and <i>N</i>-methylmorpholine in DCM at room temperature. Details of other synthetic routes for individual compounds are described in the <a href="http://pubs.acs.org/doi/suppl/10.1021/acs.jmedchem.6b00723/suppl_file/jm6b00723_si_001.pdf" class="ext-link">Supporting Information</a>.</div><div class="figure" id="sch3"><a title="Open Figure Viewer" href="#" class="thumbnail showFiguresEvent"><img alt="figure" src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/small/jm-2016-00723u_0006.gif" /><span class="overlay"></span></a><div class="caption hlFld-FigureCaption"><p class="first last">Scheme 3. <sup>a</sup></p></div><p class="last"><p class="last"><sup>a</sup>Conditions: (a) morpholine, Et<sub>3</sub>N, DCM, 16 h, 72% yield; (b) MeMgBr, toluene, reflux, 4 h and then a 10% aqueous HCl, reflux, 1 h, 70% yield; (c) NBS, benzoyl peroxide, dichlorobenzene, 140 °C, 16 h, 70% yield; (d) morpholine, K<sub>2</sub>CO<sub>3</sub>, acetonitrile, 40 °C, 16 h, 64% yield; (e) 5-fluoroisatin, KOH, EtOH, 120 °C, microwave, 20 min, 30–76% yield; (f) amine, CDMT, <i>N</i>-methylmorpholine, DCM, 20–61% yield.</p></p></div><div class="NLM_p">As highlighted above, a basic group is not required for activity at R<sup>3</sup>. Thus, derivatives of <b>2</b> with either reduced basicity (<b>40</b>, <b>41</b>, and <b>42</b>) or a nonbasic substituent (<b>38</b>, <b>43</b>, <b>44</b>) at R<sup>3</sup> showed excellent potency with the exception of amide <b>39</b>. The introduction of a conformationally restricted bridge amide as exemplified by compound <b>39</b> is detrimental for potency, possibly because it does not allow rotation of the morpholine group to adopt the optimal orientation for binding. The importance of the orientation of the morpholine substituent for activity is also highlighted by compound <b>45</b>. In this case, a change of the methylmorpholine group from para to the meta position led to a weakly active compound.</div><div class="NLM_p">On the basis of their excellent potency, good permeability, microsomal stability, and solubility (<a class="ref" href="#tbl6">Table <a class="ref" href="#tbl6">6</a></a>), compounds <b>2</b>, <b>40</b>, <b>41</b>, <b>43</b>, and <b>44</b> were progressed for efficacy studies in mice dosing at 1 mg/kg for 4 days (<a class="ref" href="#tbl8">Table <a class="ref" href="#tbl8">8</a></a>). Compounds <b>40</b>, <b>43</b>, and <b>44</b> showed excellent activity at this low dose, with reductions of parasitemia above 99%. Compound <b>41</b> showed the best survival time (14 days) comparable with <b>2</b>.</div><div class="NLM_p">Once an optimal R<sup>3</sup> substituent had been identified, we turned our attention back to the R<sup>2</sup> substituent to see if it was possible to improve the profile of compound <b>2</b> (<a class="ref" href="#tbl5">Table <a class="ref" href="#tbl5">5</a></a>). As highlighted before, lowering basicity at R<sup>2</sup> results in a reduction in potency. The replacement of the pyrrolidine for a morpholine in compound <b>46</b> led to a 12-fold drop in potency. The amide NH is also important for activity, as capping with a methyl group resulted in an 87-fold decrease in potency against <i>P</i>. <i>falciparum</i> (3D7) (<b>47</b>, EC<sub>50</sub> = 87 nM). Finally, it is possible to reduce the size of the ring on the R<sup>2</sup> substituent and retain activity as shown by compounds <b>48</b> and <b>49</b>. Compound <b>49</b> showed excellent in vivo activity in the <i>P. berghei</i> mouse model at 4 × 10 mg/kg and 4 × 3 mg/kg. (<a class="ref" href="#tbl8">Table <a class="ref" href="#tbl8">8</a></a>). However, none of these compounds offered a particular advantage to compound <b>2</b>.</div><div class="NLM_table-wrap" id="tbl5"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 5. SAR Study of the R<sup>2</sup> Substituent</div></div></div><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0015.gif" alt="" /><img src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/medium/jm-2016-00723u_0016.gif" alt="" /><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t5fn1">Table a<p class="last">Calculated p<i>K</i><sub>a</sub> using ChemAxon software.</p></div></div></div><div class="NLM_p">Although in vitro DMPK data and in vivo efficacy in the <i>P. berghei</i> model were comparable for compound <b>2</b> and the fluorinated derivative <b>41</b>, oral bioavailability in rat (33% for <b>41</b> vs 84% for <b>2</b>) was lower and rat intravenous elimination half-life (4 h for <b>41</b> vs 10 h for <b>2</b>) was shorter for <b>41</b> (<a class="ref" href="#tbl9">Table <a class="ref" href="#tbl9">9</a></a>). Therefore, compound <b>2</b> showed the best overall profile for further progression from this novel quinoline-4-carboxamide series (<a class="ref" href="#tbl9">Table <a class="ref" href="#tbl9">9</a></a> and <a class="ref" href="#fig2">Figure <a class="ref" href="#fig2">2</a></a>). Compound <b>2</b> fulfilled the efficacy and DMPK requirements for a late lead according to the MMV criteria and, following further profiling, was selected as a preclinical candidate by MMV. The studies required to profile <b>2</b> for candidate selection have been described elsewhere.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></div><div class="NLM_table-wrap" id="tbl6"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 6. Key in vitro DMPK Data for Selected Analogues</div></div></div><table class="table" border="0"><colgroup><col align="left" /><col align="char" char="." /><col align="char" char="." /><col align="char" char="." /><col align="char" char="." /><col align="char" char="." /><col align="char" char="." /><col align="char" char="." /></colgroup><thead><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center">compd</th><th class="colsep0 rowsep0" align="center" char=".">PAMPA <i>P</i><sub>e</sub> (nm/s)<a class="ref" href="#t6fn1"><sup>a</sup></a></th><th class="colsep0 rowsep0" align="center" char=".">Sol. (μM)</th><th class="colsep0 rowsep0" align="center" char=".">MLM<a class="ref" href="#t6fn2"><sup>b</sup></a> Cli (mL min<sup>–1</sup> g<sup>–1</sup>)</th><th class="colsep0 rowsep0" align="center" char=".">RLM<a class="ref" href="#t6fn3"><sup>c</sup></a> Cli (mL min<sup>–1</sup> g<sup>–1</sup>)</th><th class="colsep0 rowsep0" align="center" char=".">HLM<a class="ref" href="#t6fn4"><sup>d</sup></a> Cli (mL min<sup>–1</sup> g<sup>–1</sup>)</th><th class="colsep0 rowsep0" align="center" char=".">PPB (%)<a class="ref" href="#t6fn5"><sup>e</sup></a></th><th class="colsep0 rowsep0" align="center" char=".">hERG<a class="ref" href="#t6fn6"><sup>f</sup></a> IC<sub>50</sub> (μM)</th></tr></thead><tbody><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>25</b></td><td class="colsep0 rowsep0" align="char" char=".">2.3</td><td class="colsep0 rowsep0" align="char" char=".">232</td><td class="colsep0 rowsep0" align="char" char=".">0.8</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char=".">59</td><td class="colsep0 rowsep0" align="char" char=".">&gt;11</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>27</b></td><td class="colsep0 rowsep0" align="char" char=".">2</td><td class="colsep0 rowsep0" align="char" char=".">217</td><td class="colsep0 rowsep0" align="char" char=".">2.0</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char=".">&lt;1</td><td class="colsep0 rowsep0" align="char" char=".">49</td><td class="colsep0 rowsep0" align="char" char=".">&gt;11</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>30</b></td><td class="colsep0 rowsep0" align="char" char=".">48</td><td class="colsep0 rowsep0" align="char" char=".">232</td><td class="colsep0 rowsep0" align="char" char=".">2</td><td class="colsep0 rowsep0" align="char" char=".">0.8</td><td class="colsep0 rowsep0" align="char" char=".">1</td><td class="colsep0 rowsep0" align="char" char=".">77</td><td class="colsep0 rowsep0" align="char" char=".">&gt;11</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>2</b><a class="ref" href="#t6fn7"><sup>g</sup></a></td><td class="colsep0 rowsep0" align="char" char=".">73</td><td class="colsep0 rowsep0" align="char" char=".">216</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char=".">≤0.8</td><td class="colsep0 rowsep0" align="char" char=".">≤1.1</td><td class="colsep0 rowsep0" align="char" char=".">63</td><td class="colsep0 rowsep0" align="char" char=".">16</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>38</b></td><td class="colsep0 rowsep0" align="char" char=".">29</td><td class="colsep0 rowsep0" align="char" char=".">109</td><td class="colsep0 rowsep0" align="char" char=".">1.9</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char=".">75</td><td class="colsep0 rowsep0" align="char" char=".">11</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>40</b></td><td class="colsep0 rowsep0" align="char" char=".">63</td><td class="colsep0 rowsep0" align="char" char=".">&gt;208</td><td class="colsep0 rowsep0" align="char" char=".">1.0</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>41</b></td><td class="colsep0 rowsep0" align="char" char=".">132</td><td class="colsep0 rowsep0" align="char" char=".">208</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char=".">1.5</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>42</b></td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char=".">&gt;201</td><td class="colsep0 rowsep0" align="char" char=".">0.5</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char=".">56</td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>43</b></td><td class="colsep0 rowsep0" align="char" char=".">14</td><td class="colsep0 rowsep0" align="char" char=".">171</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char=".">0.8</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>44</b></td><td class="colsep0 rowsep0" align="char" char=".">49</td><td class="colsep0 rowsep0" align="char" char=".">&gt;217</td><td class="colsep0 rowsep0" align="char" char=".">2.0</td><td class="colsep0 rowsep0" align="char" char=".">0.6</td><td class="colsep0 rowsep0" align="char" char=".">2</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>46</b></td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char=".">&gt;210</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>47</b></td><td class="colsep0 rowsep0" align="char" char=".">137</td><td class="colsep0 rowsep0" align="char" char=".">&gt;210</td><td class="colsep0 rowsep0" align="char" char=".">&lt;0.5</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>48</b></td><td class="colsep0 rowsep0" align="char" char=".">49</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char=".">2</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>49</b></td><td class="colsep0 rowsep0" align="char" char=".">75</td><td class="colsep0 rowsep0" align="char" char=".">71</td><td class="colsep0 rowsep0" align="char" char=".">0.5</td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td><td class="colsep0 rowsep0" align="char" char="."> </td></tr></tbody></table><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t6fn1">a<p class="last">Controls: atenolol, 0.2–4.6 nm/s; propanolol, 103–159 nm/s.</p></div><div class="footnote" id="t6fn2">b<p class="last">MLM: mouse liver microsome.</p></div><div class="footnote" id="t6fn3">c<p class="last">RLM: rat liver microsome.</p></div><div class="footnote" id="t6fn4">d<p class="last">HLM: human liver microsome.</p></div><div class="footnote" id="t6fn5">e<p class="last">Mouse plasma protein binding.</p></div><div class="footnote" id="t6fn6">f<p class="last">Measured using IonWorks Patch Clamp electrophysiology.</p></div><div class="footnote" id="t6fn7">g<p class="last">Data for this compound reported previously.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div></div></div><div class="NLM_table-wrap" id="tbl7"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 7. In vivo Pharmacokinetic Profile in Mice of Key Compounds</div></div></div><table class="table" border="0"><colgroup><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /></colgroup><thead><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center"> </th><th class="rowsep1" colspan="3" align="center">intravenous at 3 mg/kg</th><th class="rowsep1" colspan="4" align="center">oral at 10 mg/kg</th></tr><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center">compd</th><th class="colsep0 rowsep0" align="center">Clb (mL min<sup>–1</sup> kg<sup>–1</sup>)</th><th class="colsep0 rowsep0" align="center">Vd<sub>ss</sub> (L/kg)</th><th class="colsep0 rowsep0" align="center"><i>T</i><sub>1/2</sub> (h)</th><th class="colsep0 rowsep0" align="center"><i>C</i><sub>max</sub> (ng/mL)</th><th class="colsep0 rowsep0" align="center">AUC (ng·min/mL)</th><th class="colsep0 rowsep0" align="center"><i>T</i><sub>max</sub> (h)</th><th class="colsep0 rowsep0" align="center"><i>F</i> (%)</th></tr></thead><tbody><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>25</b></td><td class="colsep0 rowsep0" align="left">14</td><td class="colsep0 rowsep0" align="left">3</td><td class="colsep0 rowsep0" align="left">3.2</td><td class="colsep0 rowsep0" align="left">315</td><td class="colsep0 rowsep0" align="left">92922</td><td class="colsep0 rowsep0" align="left">2</td><td class="colsep0 rowsep0" align="left">15</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>27</b></td><td class="colsep0 rowsep0" align="left">4</td><td class="colsep0 rowsep0" align="left">3.5</td><td class="colsep0 rowsep0" align="left">12.5</td><td class="colsep0 rowsep0" align="left">579</td><td class="colsep0 rowsep0" align="left">176115</td><td class="colsep0 rowsep0" align="left">2</td><td class="colsep0 rowsep0" align="left">16</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>30</b></td><td class="colsep0 rowsep0" align="left">34</td><td class="colsep0 rowsep0" align="left">7.4</td><td class="colsep0 rowsep0" align="left">2.9</td><td class="colsep0 rowsep0" align="left">193</td><td class="colsep0 rowsep0" align="left">72728</td><td class="colsep0 rowsep0" align="left">0.5</td><td class="colsep0 rowsep0" align="left">23</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>2</b><a class="ref" href="#t7fn1"><sup>a</sup></a></td><td class="colsep0 rowsep0" align="left">12<a class="ref" href="#t7fn2"><sup>b</sup></a></td><td class="colsep0 rowsep0" align="left">15<a class="ref" href="#t7fn2"><sup>b</sup></a></td><td class="colsep0 rowsep0" align="left">16<a class="ref" href="#t7fn2"><sup>b</sup></a></td><td class="colsep0 rowsep0" align="left">90<a class="ref" href="#t7fn3"><sup>c</sup></a></td><td class="colsep0 rowsep0" align="left">179272<a class="ref" href="#t7fn3"><sup>c</sup></a></td><td class="colsep0 rowsep0" align="left">1<a class="ref" href="#t7fn3"><sup>c</sup></a></td><td class="colsep0 rowsep0" align="left">74</td></tr></tbody></table><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t7fn1">a<p class="last">Data for this compound reported previously.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div><div class="footnote" id="t7fn2">b<p class="last">iv dose: 1 mg/kg.</p></div><div class="footnote" id="t7fn3">c<p class="last">po dose: 3 mg/kg.</p></div></div></div><div class="NLM_table-wrap" id="tbl8"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 8. In vivo Oral Activity in the <i>P. berghei</i> Mouse Model Peter’s Test</div></div></div><table class="table" border="0"><colgroup><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /></colgroup><thead><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center"> </th><th class="rowsep1" colspan="3" align="center">4 × 30 mg/kg</th><th class="rowsep1" colspan="3" align="center">4 × 10 mg/kg</th><th class="rowsep1" colspan="3" align="center">4 × 3 mg/kg</th><th class="rowsep1" colspan="3" align="center">4 × 1 mg/kg</th></tr><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center">compd</th><th class="colsep0 rowsep0" align="center">activity (%)</th><th class="colsep0 rowsep0" align="center">survival (days)</th><th class="colsep0 rowsep0" align="center">cure</th><th class="colsep0 rowsep0" align="center">activity (%)</th><th class="colsep0 rowsep0" align="center">survival (days)</th><th class="colsep0 rowsep0" align="center">cure</th><th class="colsep0 rowsep0" align="center">activity (%)</th><th class="colsep0 rowsep0" align="center">survival (days)</th><th class="colsep0 rowsep0" align="center">cure</th><th class="colsep0 rowsep0" align="center">activity (%)</th><th class="colsep0 rowsep0" align="center">survival (days)</th><th class="colsep0 rowsep0" align="center">cure</th></tr></thead><tbody><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>25</b></td><td class="colsep0 rowsep0" align="left">93.0</td><td class="colsep0 rowsep0" align="left">7</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>27</b></td><td class="colsep0 rowsep0" align="left">99.8</td><td class="colsep0 rowsep0" align="left">22</td><td class="colsep0 rowsep0" align="left">1/3</td><td class="colsep0 rowsep0" align="left">99.7</td><td class="colsep0 rowsep0" align="left">15</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">96.0</td><td class="colsep0 rowsep0" align="left">9</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">48.0</td><td class="colsep0 rowsep0" align="left">6.0</td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>30</b></td><td class="colsep0 rowsep0" align="left">99.9</td><td class="colsep0 rowsep0" align="left">10</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">99.9</td><td class="colsep0 rowsep0" align="left">8</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">98.0</td><td class="colsep0 rowsep0" align="left">6</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">90.0</td><td class="colsep0 rowsep0" align="left">7</td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>2</b></td><td class="colsep0 rowsep0" align="left">99.9</td><td class="colsep0 rowsep0" align="left">&gt;30</td><td class="colsep0 rowsep0" align="left">3/3</td><td class="colsep0 rowsep0" align="left">99.9</td><td class="colsep0 rowsep0" align="left">&gt;30</td><td class="colsep0 rowsep0" align="left">3/3</td><td class="colsep0 rowsep0" align="left">99.9</td><td class="colsep0 rowsep0" align="left">25</td><td class="colsep0 rowsep0" align="left">2/3</td><td class="colsep0 rowsep0" align="left">99.9</td><td class="colsep0 rowsep0" align="left">14</td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>40</b></td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">99.8</td><td class="colsep0 rowsep0" align="left">11.0</td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>41</b></td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">99.9</td><td class="colsep0 rowsep0" align="left">14</td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>43</b></td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">99.0</td><td class="colsep0 rowsep0" align="left">7</td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>44</b></td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">&lt;40</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>49</b></td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left">99.1</td><td class="colsep0 rowsep0" align="left">20.3</td><td class="colsep0 rowsep0" align="left">1/3</td><td class="colsep0 rowsep0" align="left">99.2</td><td class="colsep0 rowsep0" align="left">9.3</td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td><td class="colsep0 rowsep0" align="left"> </td></tr></tbody></table></div><div class="NLM_table-wrap" id="tbl9"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 9. In vivo Pharmacokinetic Parameters in Male Sprague Dawley Rat</div></div></div><table class="table" border="0"><colgroup><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /></colgroup><thead><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center"> </th><th class="rowsep1" colspan="3" align="center">intravenous at 1 mg/kg</th><th class="rowsep1" colspan="4" align="center">oral at 3 mg/kg</th></tr><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center">compd</th><th class="colsep0 rowsep0" align="center">Clb (mL min<sup>–1</sup> kg<sup>–1</sup>)</th><th class="colsep0 rowsep0" align="center">Vd<sub>ss</sub> (L/kg)</th><th class="colsep0 rowsep0" align="center"><i>T</i><sub>1/2</sub> (h)</th><th class="colsep0 rowsep0" align="center"><i>C</i><sub>max</sub> (ng/mL)</th><th class="colsep0 rowsep0" align="center"><i>T</i><sub>max</sub> (h)</th><th class="colsep0 rowsep0" align="center">AUC (ng·min/mL)</th><th class="colsep0 rowsep0" align="center"><i>F</i> (%)</th></tr></thead><tbody><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>2</b><a class="ref" href="#t9fn1"><sup>a</sup></a></td><td class="colsep0 rowsep0" align="left">18</td><td class="colsep0 rowsep0" align="left">15</td><td class="colsep0 rowsep0" align="left">10</td><td class="colsep0 rowsep0" align="left">180<a class="ref" href="#t9fn2"><sup>b</sup></a></td><td class="colsep0 rowsep0" align="left">4<a class="ref" href="#t9fn2"><sup>b</sup></a></td><td class="colsep0 rowsep0" align="left">200542<a class="ref" href="#t9fn2"><sup>b</sup></a></td><td class="colsep0 rowsep0" align="left">84</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>41</b></td><td class="colsep0 rowsep0" align="left">32</td><td class="colsep0 rowsep0" align="left">10</td><td class="colsep0 rowsep0" align="left">4</td><td class="colsep0 rowsep0" align="left">29</td><td class="colsep0 rowsep0" align="left">8</td><td class="colsep0 rowsep0" align="left">30400</td><td class="colsep0 rowsep0" align="left">33</td></tr></tbody></table><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t9fn1">a<p class="last">Data for this compound reported previously.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div><div class="footnote" id="t9fn2">b<p class="last">po dose: 5 mg/kg.</p></div></div></div><div class="figure" id="fig2"><a title="Open Figure Viewer" href="#" class="thumbnail showFiguresEvent"><img alt="figure" src="/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901/images/small/jm-2016-00723u_0003.gif" /><span class="overlay"></span></a><div class="caption hlFld-FigureCaption"><p class="first last">Figure 2. Mean blood concentration time profile of compounds <b>2</b> and <b>41</b> following intravenous or oral administration to male Sprague Dawley rats.</p></div></div><div class="NLM_p">We also profiled key compounds of this series for their activity against different life stages of the malaria parasite life cycle (<a class="ref" href="#tbl10">Table <a class="ref" href="#tbl10">10</a></a>). Following a mosquito bite (blood meal), sporozoites are injected into the skin and migrate in the bloodstream to the liver, where they invade liver hepatocytes and then develop into liver schizonts. Compounds active against liver schizonts can potentially prevent disease development and be used in chemoprotection. Compounds <b>2</b>, <b>27</b>, <b>30</b>, and <b>38</b> showed low nanomolar activity against the live schizont forms of <i>Plasmodium yoelli</i>.<a onclick="showRef(event, 'ref14'); return false;" href="JavaScript:void(0);" class="ref">(14)</a> Several compounds were also tested in vitro against <i>P. falciparum</i> late stage (IV–V) gametocytes. Stage V gametocytes, typically insensitive to antimalarial drugs, are infectious to mosquitoes and responsible for the transmission of the disease. 4-Quinolinecarboxamides, in particular compounds <b>2</b> and <b>30</b>, are potent antigametocytocidal (stage IV–V) with nanomolar activities.<a onclick="showRef(event, 'ref15'); return false;" href="JavaScript:void(0);" class="ref">(15)</a> The ability of compounds of this series to block transmission was further tested in the <i>P. berghei</i> ookinete development assay, which simulates in vitro the first 24 h of parasite development in the mosquito midgut, from mature gametocyte transformation into gametes, through fertilization and to mature ookinete development. Compounds <b>2</b>, <b>27</b>, <b>30</b> and <b>38</b> showed nanomolar potency in this assay.<a onclick="showRef(event, 'cit14b'); return false;" href="JavaScript:void(0);" class="ref">(14b)</a></div><div class="NLM_table-wrap" id="tbl10"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 10. Activity against <i>Plasmodium</i> Life Cycle Stages</div></div></div><table class="table" border="0"><colgroup><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /></colgroup><thead><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center">compd</th><th class="colsep0 rowsep0" align="center"><i>Pf</i> (3D7) EC<sub>50</sub> (nM)</th><th class="colsep0 rowsep0" align="center"><i>Py</i> liver stage EC<sub>50</sub> (nM)</th><th class="colsep0 rowsep0" align="center"><i>Pf</i> GAM IV–V EC<sub>50</sub> (nM)<a class="ref" href="#t10fn1"><sup>a</sup></a></th><th class="colsep0 rowsep0" align="center"><i>Pb</i> pokinete EC<sub>50</sub> (nM)</th></tr></thead><tbody><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>27</b></td><td class="colsep0 rowsep0" align="left">4</td><td class="colsep0 rowsep0" align="left">18</td><td class="colsep0 rowsep0" align="left">104</td><td class="colsep0 rowsep0" align="left">5</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>30</b></td><td class="colsep0 rowsep0" align="left">6</td><td class="colsep0 rowsep0" align="left">1</td><td class="colsep0 rowsep0" align="left">39</td><td class="colsep0 rowsep0" align="left">14</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>2</b></td><td class="colsep0 rowsep0" align="left">1</td><td class="colsep0 rowsep0" align="left">1<a class="ref" href="#t10fn2"><sup>b</sup></a></td><td class="colsep0 rowsep0" align="left">24</td><td class="colsep0 rowsep0" align="left">5<a class="ref" href="#t10fn2"><sup>b</sup></a></td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>38</b></td><td class="colsep0 rowsep0" align="left">4</td><td class="colsep0 rowsep0" align="left">4</td><td class="colsep0 rowsep0" align="left">152</td><td class="colsep0 rowsep0" align="left">15</td></tr></tbody></table><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t10fn1">a<p class="last">Run in duplicate. Reference controls: pyronaridine EC<sub>50</sub> = 3108 nM, tafenoquine EC<sub>50</sub> = 5250 nM, artemisinin EC<sub>50</sub> = 0.8 nM.</p></div><div class="footnote" id="t10fn2">b<p class="last">Data reported previously.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div></div></div><div class="NLM_p">Finally, compounds <b>2</b> and <b>30</b> were tested against several <i>Plasmodium falciparum</i> drug resistant strains (K1, W2, 7G8, TM90C2A, D6, and V1/S) showing similar levels of activity across strains<a onclick="showRef(event, 'cit14b'); return false;" href="JavaScript:void(0);" class="ref">(14b)</a> (<a class="ref" href="#tbl11">Table <a class="ref" href="#tbl11">11</a></a>).</div><div class="NLM_table-wrap" id="tbl11"><div class="hlFld-FigureCaption"><div class="NLM_caption"><div class="title2">Table 11. Activity against <i>Plasmodium falciparum</i> Resistant Strains<a class="ref" href="#t11fn1"><sup>a</sup></a></div></div></div><table class="table" border="0"><colgroup><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /><col align="left" /></colgroup><thead><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center"> </th><th class="rowsep1" colspan="7" align="center">EC<sub>50</sub> (nM)</th></tr><tr valign="top" class="colsep0"><th class="colsep0 rowsep0" align="center">compd</th><th class="colsep0 rowsep0" align="center">NF5</th><th class="colsep0 rowsep0" align="center">K1</th><th class="colsep0 rowsep0" align="center">W2</th><th class="colsep0 rowsep0" align="center">7G8</th><th class="colsep0 rowsep0" align="center">TM90C2A</th><th class="colsep0 rowsep0" align="center">D6</th><th class="colsep0 rowsep0" align="center">V1/S</th></tr></thead><tbody><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>30</b></td><td class="colsep0 rowsep0" align="left">0.5</td><td class="colsep0 rowsep0" align="left">0.8</td><td class="colsep0 rowsep0" align="left">0.6</td><td class="colsep0 rowsep0" align="left">0.7</td><td class="colsep0 rowsep0" align="left">0.5</td><td class="colsep0 rowsep0" align="left">0.7</td><td class="colsep0 rowsep0" align="left">0.9</td></tr><tr valign="top" class="colsep0"><td class="colsep0 rowsep0" align="left"><b>2</b></td><td class="colsep0 rowsep0" align="left">0.3</td><td class="colsep0 rowsep0" align="left">0.4</td><td class="colsep0 rowsep0" align="left">0.4</td><td class="colsep0 rowsep0" align="left">0.4</td><td class="colsep0 rowsep0" align="left">0.4</td><td class="colsep0 rowsep0" align="left">0.4</td><td class="colsep0 rowsep0" align="left">0.7</td></tr></tbody></table><div class="NLM_table-wrap-foot" id="IDtable-wrap-foot"><div class="footnote" id="t11fn1">a<p class="last">Data for compound <b>2</b> have been previously reported.<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a></p></div></div></div></div><div id="sec3" class="NLM_sec NLM_sec_level_1"><ul class="anchors"><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="_i15">Conclusion</h2><hr /><div class="NLM_p">We have evolved a malaria phenotypic hit series, which started with moderate in vitro activity and selectivity but suboptimal metabolic stability and physicochemical properties, into an early lead compound <b>25</b> with improved potency, ligand efficiency, metabolic stability, and in vivo efficacy. The lead optimization phase focused on improving low oral bioavailability caused by the poor permeability of the early lead. The most advanced quinoline-4-carboxamides showed exceptional in vitro and in vivo activities, with a reduction of parasitemia of more than 99% when administered at low doses (4 × 1 mg/kg, 4 days, po) in the <i>P. berghei</i> mouse model. In addition to potent intraerythrocyte activity, compounds in this series showed similar potency against liver schizonts, gametocytes, and ookinetes in vitro. Furthermore, a combination of in vitro and in vivo activities across the different stages of the malaria parasite life cycle demonstrated the potential of this novel quinoline-4-carboxamide series to meet a number of the MMV’s malaria target candidate profiles (TCPs), as previously described.<a onclick="showRef(event, 'ref7'); return false;" href="JavaScript:void(0);" class="ref">(7)</a></div><div class="NLM_p last">Compound <b>2</b> has been extensively profiled<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> in vitro and in vivo and displays activity against multiple life-cycle stages of the parasite with a long half-life in preclinical animal studies. With this profile, compound <b>2</b> has the potential for single dose treatment of malaria as part of a combination therapy, together with transmission blocking potential (TCP2 and TCP3b).<a onclick="showRef(event, 'ref7'); return false;" href="JavaScript:void(0);" class="ref">(7)</a> It also has the potential for chemoprotection (TCP4).<a onclick="showRef(event, 'ref7'); return false;" href="JavaScript:void(0);" class="ref">(7)</a> Compound <b>2</b> was active against parasites that show resistance to currently used antimalarials and has a novel mode of action through inhibition of elongation factor 2 (<i>Pf</i>eEF2), which is involved in protein synthesis. The favorable potency, selectivity, DMPK properties, efficacy, safety profile, and novel mechanism of action support the progression of <b>2</b> toward clinical development.</div></div><div id="sec4" class="NLM_sec NLM_sec_level_1"><ul class="anchors"><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="_i16">Experimental Section</h2><hr /><div id="sec4.1.1.1" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e2863">Chemistry. General</span><div class="NLM_p last">Solvents and reagents were purchased from commercial suppliers and used without further purification. Dry solvents were purchased in Sure/Seal bottles stored over molecular sieves. Reactions using microwave irradiation were carried out in a Biotage Initiator microwave. Normal phase TLCs were carried out on precoated silica plates (Kieselgel 60 F<sub>254</sub>, BDH) with visualization via UV light (UV 254/365 nm) and/or ninhydrin solution. Flash chromatography was performed using Combiflash Companion Rf (Teledyne ISCO) and prepacked silica gel columns purchased from Grace Davison Discovery Science or SiliCycle. Mass-directed preparative HPLC separations were performed using a Waters HPLC (2545 binary gradient pumps, 515 HPLC make-up pump, 2767 sample manager) connected to a Waters 2998 photodiode array and a Waters 3100 mass detector. Preparative HPLC separations were performed with a Gilson HPLC (321 pumps, 819 injection module, 215 liquid handler/injector) connected to a Gilson 155 UV/vis detector. On both instruments, HPLC chromatographic separations were conducted using Waters XBridge C18 columns, 19 mm × 100 mm, 5 μm particle size, using 0.1% ammonia in water (solvent A) and acetonitrile (solvent B) as mobile phase. <sup>1</sup>H NMR, <sup>19</sup>F NMR spectra were recorded on a Bruker Avance DPX 500 spectrometer (<sup>1</sup>H at 500.1 MHz, <sup>19</sup>F at 470.5 MHz) or a Bruker Avance DPX 300 (<sup>1</sup>H at 300 MHz). Chemical shifts (δ) are expressed in ppm recorded using the residual solvent as the internal reference in all cases. Signal splitting patterns are described as singlet (s), doublet (d), triplet (t), quartet (q), multiplet (m), broadened (br), or a combination thereof. Coupling constants (<i>J</i>) are quoted to the nearest 0.1 Hz. Low resolution electrospray (ES) mass spectra were recorded on a Bruker Daltonics MicrOTOF mass spectrometer run in positive mode. High resolution mass spectroscopy (HRMS) was performed using a Bruker Daltonics MicroTof mass spectrometer. LC–MS analysis and chromatographic separation were conducted with a Bruker Daltonics MicrOTOF mass spectrometer or an Agilent Technologies 1200 series HPLC connected to an Agilent Technologies 6130 quadrupole LC/MS, where both instruments were connected to an Agilent diode array detector. The column used was a Waters XBridge column (50 mm × 2.1 mm, 3.5 μm particle size), and the compounds were eluted with a gradient of 5–95% acetonitrile/water + 0.1% ammonia. All final compounds showed chemical purity of ≥95% as determined by the UV chromatogram (190–450 nm) obtained by LC–MS analysis. Unless otherwise stated herein reactions have not been optimized.</div></div><div id="sec4.1.2" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e2890">General Procedure A: Preparation of 2-(<i>p</i>-Tolyl)quinilone-4-carboxylic Acids (<b>3</b>)</span><div class="NLM_p last">To a mixture of the corresponding isatin (5 mmol) in ethanol (10 mL) were added the corresponding acetophenone (5 mmol), water (10 mL), and potassium hydroxide (2.80 g, 50 mmol). The reaction mixture was heated under microwave irradiation at 125 °C for 20 min. The resulting dark red colored solution was diluted with water (50 mL) and acidified by adding HCl (2 M, 30 mL). The resulting precipitate (yellow to ochre in color) was collected by filtration, washed with water (50 mL), ethyl acetate (100 mL), and dichloromethane (25 mL). The remaining solid was used in the next step without further purification.</div></div><div id="sec4.1.3" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e2901">6-Chloro-2-(<i>p</i>-tolyl)quinolone-4-carboxylic Acids (<b>3</b>, R<sup>1</sup> = Cl)</span><div class="NLM_p last">Prepared using general procedure A. Yield, 58% (861 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 8.82 (d, <i>J</i> = 2.3 Hz, 1H), 8.44 (s, 1H), 8.19 (d, <i>J</i> = 8.2 Hz, 2H), 8.13 (d, <i>J</i> = 9.0 Hz, 1H), 7.82 (dd, <i>J</i> = 2.3, 9.0 Hz, 1H), 7.38 (d, <i>J</i> = 8.0 Hz, 2H), 2.41 (s, 3H) ppm; LC–MS <i>m</i>/<i>z</i> 298 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.4" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e2948">2-(<i>p</i>-Tolyl)quinolone-4-carboxylic Acids (<b>3</b>, R<sup>1</sup> = H)</span><div class="NLM_p last">Prepared using general procedure A. Yield, 29% (384 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 8.65 (d, 1H, <i>J</i> = 8.5 Hz), 8.45 (s, 1H), 8.22 (d, 2H, <i>J</i> = 8.2 Hz), 8.16 (d, 1H, <i>J</i> = 7.8 Hz), 7.85 (ddd, 1H, <i>J</i> = 1.4, 6.9, 8.4 Hz), 7.70 (ddd, 1H, <i>J</i> = 1.3, 6.9, 8.3 Hz), 7.39 (d, 2H, <i>J</i> = 7.9 Hz), 2.41 (s, 3H) ppm; LC–MS <i>m</i>/<i>z</i> 251 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.5" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e2998">General Procedure B: Preparation of 2-(<i>p</i>-Tolyl)quinolone-4-carboxamides (<b>10</b>–<b>18</b>)</span><div class="NLM_p last">To a solution of quinolinecarboxylic acid <b>3</b> (0.5 mmol) in DMF (3 mL) was added diisopropylethylamine (0.07 mL, 0.75 mmol) followed by EDC (144 mg, 0.75 mmol) and HOBt (101 mg, 0.75 mmol). After 5 min the corresponding amine (1 mmol) was added followed by DMF (2 mL). The reaction mixture was stirred at room temperature overnight. The reaction was diluted with water (50 mL) and brine (10 mL) and extracted with ethyl acetate (30 mL). Solvents were removed, and the resulting off white solid was washed with dichloromethane and filtered. Amides that were soluble in dichloromethane were purified by column chromatography on silica.</div></div><div id="sec4.1.6" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3015">6-Chloro-<i>N</i>-(pyridine-3-yl)-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>10</b>)</span><div class="NLM_p last">Prepared using general procedure B. Yield, 25% (47 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 11.06 (br s, 1H), 8.96 (d, <i>J</i> = 2.0 Hz, 1H), 8.48 (s, 1H), 8.39 (dd, <i>J</i> = 1.4, 4.8 Hz, 1H), 8.30–8.25 (m, 4H), 8.18 (d, <i>J</i> = 9.0 Hz, 1H), 7.87 (d, <i>J</i> = 2.4, 9.0 Hz, 1H), 7.47 (dd, <i>J</i> = 4.8, 8.3 Hz, 1H), 7.41 (d, <i>J</i> = 8.3 Hz, 2H), 2.41 (s, 3H) ppm; HRMS for C<sub>22</sub>H<sub>17</sub>ClN<sub>3</sub>O (M + H) <sup>+</sup> calcd 374.1055, found 374.1051.</div></div><div id="sec4.1.7" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3069"><i>N</i>-(Pyridine-3-yl)-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>12</b>)</span><div class="NLM_p last">Prepared using general procedure B. Yield, 41% (69 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 11.10 (s, 1H), 9.02 (d, <i>J</i> = 1.9 Hz, 1H), 8.44–8.43 (m, 2H), 8.34–8.31 (m, 3H), 7.92–7.89 (m, 1H), 7.73–7.70 (m, 1H), 7.52 (dd, <i>J</i> = 4.8, 8.2 Hz, 1H), 7.45 (d, <i>J</i> = 8.0 Hz, 2H), 2.46 (s, 3H) ppm; LC–MS <i>m</i>/<i>z</i> 340 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.8" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3109">6-Chloro-<i>N</i>-(3-(dimethylamino)ethyl)-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>13</b>)</span><div class="NLM_p last">Prepared using general procedure B. Product was purified by column chromatography using a 4 g silica gel cartridge. Solvent A: DCM. Solvent B: 20% MeOH in DCM. Gradient: 3 min hold 100% A, 15 min ramp to 50% B, 2 min hold at 50% B. Fractions containing product were combined and concentrated to dryness under reduced pressure to obtain <b>13</b>. Yield, 27% (50 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) 8.20 (d, <i>J</i> = 2.4 Hz, 1H), 8.08–8.05 (m, 1H), 7.99 (d, <i>J</i> = 8.2 Hz, 2H), 7.84 (s, 1H), 7.64 (dd, <i>J</i> = 2.2, 9.0 Hz, 1H), 7.33–7.28 (2H, m), 7.06 (1H, s), 3.65 (q, <i>J</i> = 5.6 Hz, 2H), 2.62 (t, <i>J</i> = 5.9 Hz, 2H), 2.45 (s, 3H), 2.33 (s, 6H); LC–MS <i>m</i>/<i>z</i> 368 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.9" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3157">6-Chloro-<i>N</i>-(3-(dimethylamino)propyl)-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>14</b>)</span><div class="NLM_p last">Prepared using general procedure B. Yield, 28% (53 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.51 (br s, 1H), 8.34 (d, 1H, <i>J</i> = 2.4 Hz), 8.08 (d, 1H, <i>J</i> = 9.0 Hz), 8.04 (d, 2H, <i>J</i> = 8.2 Hz), 7.92 (s, 1H), 7.65 (dd, 1H, <i>J</i> = 2.1, 9.0 Hz), 7.30 (d, 2H, <i>J</i> = 8.2 Hz), 3.66 (q, 2H, <i>J</i> = 5.6 Hz), 2.51 (t, 2H, <i>J</i> = 5.6 Hz), 2.42 (s, 3H), 2.19 (s, 6H), 1.84–1.79 (m, 2H) ppm; HRMS for C<sub>22</sub>H<sub>25</sub>ClN<sub>3</sub>O (M + H) <sup>+</sup> calcd 382.1681, found 382.1673.</div></div><div id="sec4.1.10" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3212">6-Chloro-<i>N</i>-(2-morpholinoethyl)-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>15</b>)</span><div class="NLM_p last">Prepared using general procedure B. Yield, 22% (45 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 8.88 (t, <i>J</i> = 5.6 Hz, 1H), 8.31 (d, <i>J</i> = 2.4 Hz, 1H), 8.24–8.22 (m, 2H), 8.23 (s, 1H), 8.19 (s, 1H), 8.14 (d, <i>J</i> = 9.0 Hz, 1H), 7.85 (dd, <i>J</i> = 2.4, 9.0 Hz, 1H), 7.40 (d, <i>J</i> = 8.0 Hz, 2H), 3.65 (t, <i>J</i> = 4.5 Hz, 4H), 3.52 (q, <i>J</i> = 6.4 Hz, 2H), 2.57–2.54 (m, 2H), 2.41 (s, 3H) ppm; LC–MS <i>m</i>/<i>z</i> 410 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.11" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3267">6-Chloro-<i>N</i>-(2-(4-methylpiperazin-1-yl)ethyl)-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>16</b>)</span><div class="NLM_p last">Prepared using general procedure B. Yield, 27% (55 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 8.30 (d, 1H, <i>J</i> = 2.4 Hz), 8.23 (d, <i>J</i> = 8.2 Hz, 2H), 8.18–8.13 (m, 2H), 7.85 (dd, <i>J</i> = 2.4, 9.0 Hz, 1H), 7.40 (d, <i>J</i> = 8.0 Hz, 2H), 3.54–3.48 (m, 2H), 2.55 (t, <i>J</i> = 6.4 Hz, 4H), 2.52–2.50 (m, 4H), 2.41 (s, 5H), 2.22 (s, 3H) ppm; LC–MS <i>m</i>/<i>z</i> 408 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.12" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3314">6-Chloro-<i>N</i>-(2-(piperidin-1-yl)ethyl-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>17</b>)</span><div class="NLM_p last">Prepared using general procedure B. Yield, 27% (55 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 8.93 (t, <i>J</i> = 5.6 Hz, 1H), 8.39 (d, <i>J</i> = 2.4 Hz, 1H), 8.33–8.31 (m, 2H), 8.27 (s, 1H), 8.23 (d, <i>J</i> = 9.0 Hz, 1H), 7.94 (dd, <i>J</i> = 2.4, 9.0 Hz, 1H), 7.49 (d, <i>J</i> = 8.1 Hz, 2H), 3.60 (q, <i>J</i> = 6.4 Hz, 2H), 2.56–2.49 (m, 7H), 1.67–1.63 (m, 4H), 1.53–1.49 (m, 2H) ppm; LC–MS <i>m</i>/<i>z</i> 408 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.13" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3364">6-Chloro-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl-2-(<i>p</i>-tolyl)quinoline-4-carboxamide (<b>18</b>)</span><div class="NLM_p last">Prepared using general procedure B. Yield, 43% (85 mg); <sup>1</sup>H NMR (500 MHz, DMSO-<i>d</i><sub>6</sub>) δ 8.87 (t, <i>J</i> = 5.7 Hz, 1H), 8.30 (d, <i>J</i> = 2.7 Hz, 1H), 8.22 (d, <i>J</i> = 8.8 Hz, 2H), 8.17 (s, 1H), 8.12 (d, <i>J</i> = 10.0 Hz, 1H), 7.82 (dd, <i>J</i> = 2.7, 8.8 Hz, 1H), 7.38 (d, <i>J</i> = 8.1 Hz, 2H), 3.50 (q, <i>J</i> = 5.7 Hz, 2H), 2.65 (t, <i>J</i> = 7.8 Hz, 2H), 2.56–2.54 (m, 4H), 2.30 (s, 3H), 1.73 (m, 4H) ppm; HRMS for C<sub>23</sub>H<sub>25</sub>ClN<sub>3</sub>O (M + H)<sup>+</sup> calcd 394.1681, found 394.1663.</div></div><div id="sec4.1.14" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3424">6-Fluoro-2-hydroxy-quinoline-4-carboxylic Acid (<b>4</b>, R<sup>1</sup> = F)</span><div class="NLM_p last">A stirred suspension of 5-fluoroisatin (10.00 g, 61 mmol) and malonic acid (18.91 g, 182 mmol) in acetic acid (400 mL) was refluxed for 16 h. Acetic acid was removed under reduced pressure, and the residue was suspended in water (400 mL), filtered, and washed with water (300 mL) to give a brown solid. The solid was stirred in NaHCO<sub>3</sub> saturated aqueous solution (800 mL), and the insoluble material was filtered off. The filtrate was acidified to pH 1–2 with concentrated HCl, and the resulting precipitate was filtered, washed with water (300 mL), and dried. The resulting pale yellow solid was used directly for synthesis of <b>4</b> without further purification. Yield, 54% (10 g); <sup>1</sup>H NMR (500 MHz; DMSO-<i>d</i><sub>6</sub>) δ 2.08 (s, 1.5 H), 7.01 (s, 1H), 7.35–7.37 (m, 0.5 H)*, 7.48–7.49 (m, 2H), 7.64–7.68 (m, 0.9H)*, 8.01–8.04 (m, 1H), 12.29 (brs, 1H), 13.38 (brs, 0.7H)* ppm; LC–MS purity 63%, <i>m</i>/<i>z</i> 208 (M + H)<sup>+</sup>; * corresponds to impurity.</div></div><div id="sec4.1.15" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3459">6-Chloro-2-hydroxyquinoline-4-carboxylic Acid (<b>4</b>, R<sup>1</sup> = Cl)</span><div class="NLM_p last">A stirred suspension of 6-chloroisatin (10.00 g, 55 mmol) and malonic acid (17.00 g, 165 mmol) in acetic acid (400 mL) was refluxed for 16 h. Acetic acid was removed under reduced pressure, and the residue was suspended in water (400 mL), filtered, and washed with water (300 mL) to give a gray solid. The solid was stirred in NaHCO<sub>3</sub> saturated aqueous solution (800 mL), and the insoluble material was filtered off. The filtrate was acidified to pH 1–2 with concentrated HCl, and the precipitate was filtered, washed with water, and dried. The resulting pale yellow solid was used for the synthesis of <b>4</b> without further purification. Yield, 54% (9.5 g, 42 mmol); <sup>1</sup>H NMR (500 MHz; DMSO-<i>d</i><sub>6</sub>) δ 7.00 (s, 1H), 7.42 (d, 1H, <i>J</i> = 8.8 Hz), 7.58 (d, 0.3 H, <i>J</i> = 8.9 Hz)*, 7.60–7.62 (m, 1.3 H), 7.81 (dd, 0.3H, <i>J</i> = 2.3 Hz, <i>J</i> = 8.9 Hz)*, 8.29 (d, 1H, <i>J</i> = 2.4 Hz), 12.28 (brs, 1H), 13.22 (brs, 0.3 H)* ppm; LC–MS purity 65%, <i>m</i>/<i>z</i> 224 (M + H)<sup>+</sup>; * corresponds to impurity.</div></div><div id="sec4.1.16" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3510">2-Chloro-6-fluoro-<i>N</i>-(2-pyrrolidin-1-ylethyl)quinoline-4-carboxamide (<b>5</b>, R<sup>1</sup> = F)</span><div class="NLM_p last">To a stirred suspension of 6-fluoro-2-hydroxyquinoline-4-carboxylic acid (<b>4</b>, R<sup>1</sup> = F) (10.00 g, 48 mmol) in anhydrous DCM (350 mL) were added anhydrous DMF (7 mL) and thionyl chloride (14 mL, 193 mmol) under argon at room temperature. The mixture was refluxed for 3 h and then allowed to cool to room temperature. The solvents were removed under reduced pressure, and the residue was dissolved in anhydrous THF (350 mL) under argon. 2-Pyrrolidin-1-ylethanamine (18 mL, 145 mmol) was added, and the reaction was stirred at room temperature for 16 h. Solvents were removed under vacuum and the residue was partitioned between NaHCO<sub>3</sub> saturated aqueous solution (250 mL) and DCM (2 × 200 mL). The organic layers were combined, dried over MgSO<sub>4</sub>, filtered, and evaporated under reduced pressure. The crude product was purified by column chromatography using a 120 g silica gel cartridge. Solvent A: DCM. Solvent B: 10% MeOH–NH<sub>3</sub> in DCM. Gradient: 2 min hold 100% A followed by 18 min ramp to 30% B and then 15 min hold at 30% B. Fractions containing product were combined and concentrated to dryness under reduced pressure to obtain the desired compound as an off-white solid. Yield, 27% (4.59 g); <sup>1</sup>H NMR (500 MHz; CDCl<sub>3</sub>) δ 8.07 (dd, <i>J</i> = 5.4, 9.2 Hz, 1H), 7.99 (dd, <i>J</i> = 2.8, 9.7 Hz, 1H), 7.56 (ddd, <i>J</i> = 2.8, 7.9, 9.2 Hz, 1H), 7.53 (s, 1H), 6.88 (brs, 1H), 3.65–3.69 (m, 2H), 2.81 (t, <i>J</i> = 5.5 Hz, 2H), 2.64 (brs, 4H), 1.83–1.85 (m, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −110.03 ppm; LC–MS <i>m</i>/<i>z</i> 322 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.17" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3574">2,6-Chloro-<i>N</i>-(2-pyrrolidin-1-ylethyl)quinoline-4-carboxamide (<b>5</b>, R<sup>1</sup> = Cl)</span><div class="NLM_p last">To a stirred suspension of 6-chloro-2-hydroxyquinoline-4-carboxylic acid (<b>3</b>) (8.50 g, 38 mmol) in anhydrous DCM (250 mL) were added anhydrous DMF (2 mL) and thionyl chloride (11 mL, 152 mmol) at room temperature under argon. The mixture was refluxed for 3 h and then allowed to cool to room temperature. The solvents were removed under reduced pressure, and the residue was dissolved in anhydrous THF (300 mL) under argon. 2-Pyrrolidin-1-ylethanamine (14 mL, 114 mmol) was added, and the reaction was stirred at room temperature for 16 h. Solvents were removed under vacuum and the residue was partitioned between NaHCO<sub>3</sub> saturated aqueous solution (250 mL) and DCM (2 × 250 mL). The organic layers were combined, dried over MgSO<sub>4</sub>, filtered, and evaporated under reduced pressure. The crude was purified by column chromatography using a 120 g silica gel cartridge. Solvent A: DCM. Solvent B: 10% MeOH–NH<sub>3</sub> in DCM. Gradient: 2 min hold 100% A followed by 18 min ramp to 30% B and then 15 min hold at 30% B. The relevant fractions were combined and concentrated to dryness under reduced pressure to obtain the desired product as an off-white solid. Yield, 43% (5.6 g); <sup>1</sup>H NMR (500 MHz; CDCl<sub>3</sub>) δ 8.27 (d, <i>J</i> = 2.3 Hz, 1H), 7.97 (d, <i>J</i> = 9.0 Hz, 1H), 7.70 (dd, <i>J</i> = 2.3,9.0 Hz, 1H), 6.83 (brs, 1H), 7.48 (s, 1H), 3.64 (dt, <i>J</i> = 5.2, 11.6 Hz, 2H), 2.74–2.77 (m, 2H), 2.57–2.60 (m, 4H), 1.78–1.81 (m, 4H) ppm; LC–MS <i>m</i>/<i>z</i> 338 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.18" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3629">6-Fluoro-2-((3-methylisoxazol-5-yl)amino-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>20</b>)</span><div class="NLM_p last">To a solution of <b>5</b> (R<sup>1</sup> = F) (65 mg, 0.2 mmol) and 5-amino-3-methylisoxazole (39 mg, 0.4 mmol), BINAP (33 mg, 0.05 mmol) in dioxane (4 mL) were added sodium <i>tert</i>-butoxide (38 mg, 0.4 mmol) and palladium acetate (9 mg, 0.04 mmol). Reaction was heated at 115 °C overnight in a sealed tube. Reaction crude was filtered through Celite, and the filtrate was partitioned between water (5 mL) and DCM (25 mL). Organic phase was dried over MgSO<sub>4</sub>, and solvents were removed under reduce pressure. Product was purified by column chromatography on a 4 g silica cartridge using A (DCM) and B (10% MeOH–NH<sub>3</sub> in DCM). Fractions containing product were pooled together to obtain <b>20</b> as a white solid. Yield, 13% (10 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.94 (s, 1H), 7.62–7.57 (m, 2H), 7.32 (dd, <i>J</i> = 2.8, 8.2 Hz, 1H), 6.88 (s, 1H), 5.68–5.63 (m, 1H), 3.80 (d, <i>J</i> = 4.6 Hz, 2H), 2.95 (t, <i>J</i> = 5.3 Hz, 2H), 2.80 (s, 4H), 2.27 (s, 3H), 1.77 (s, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −117.06 ppm; LC–MS <i>m</i>/<i>z</i> 384 (M + 1).</div></div><div id="sec4.1.19" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3687">General Procedure C: Preparation of 2-Amino-4-carboxamides (<b>21</b>–<b>30</b>)</span><div class="NLM_p last">A solution of <b>5</b> (1 equiv) and the corresponding amine (3 equiv) in acetonitrile (2.5 mL) in a microwave vial was heated at 170 °C for 1 h under microwave irradiation. Solvents were removed and product was purified by column chromatography on 4 g silica cartridges using A (DCM) and B (10% MeOH–NH<sub>3</sub> in DCM).</div></div><div id="sec4.1.20" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3704">6-Fluoro-2-(4-methylpiperazin-1-yl)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>21</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = F) (0.2 mmol, 65 mg), light yellow solid. Yield, 26% (20 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.72–7.64 (m, 2H), 7.34–7.29 (m, 1H), 7.13 (s, 1H), 6.83 (s, 1H), 3.76 (dd, <i>J</i> = 5.0, 5.0 Hz, 4H), 3.68–3.62 (m, 2H), 2.78 (dd, <i>J</i> = 5.9, 5.9 Hz, 2H), 2.61–2.54 (m, 8H), 2.38 (s, 3H), 1.81–1.78 (m, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −118.04 ppm; LC–MS <i>m</i>/<i>z</i> 386 (M + 1).</div></div><div id="sec4.1.21" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3746">2-(5,6-Dihydroimidazo[1,2-<i>a</i>]pyrazine-7(8<i>H</i>)-yl)-6-fluoro-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>22</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = F) (0.6 mmol, 96 mg), white solid. Yield, 18% (15 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.78–7.71 (m, 2H), 7.39–7.34 (m, 1H), 7.23 (s, 1H), 7.13–7.11 (m, 1H), 7.04–7.03 (m, 1H), 6.88–6.87 (m, 1H), 4.88 (s, 2H), 4.28 (t, <i>J</i> = 5.4 Hz, 2H), 4.14 (t, <i>J</i> = 5.4 Hz, 2H), 3.67–3.62 (m, 2H), 2.77 (t, <i>J</i> = 6.0 Hz, 2H), 2.60–2.57 (m, 4H), 1.82–1.77 (m, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −117.16 ppm; LC–MS <i>m</i>/<i>z</i> 409 (M + 1).</div></div><div id="sec4.1.22" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3798">6-Fluoro-2-(4-morpholinopiperidin-1-yl)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>23</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = F) (0.2 mmol, 65 mg), yellow solid. Yield, 22% (20 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.71–7.64 (m, 2H), 7.35–7.30 (m, 1H), 7.14 (s, 1H), 6.77 (s, 1H), 4.55 (d, <i>J</i> = 13.2 Hz, 2H), 3.74 (t, <i>J</i> = 4.7 Hz, 4H), 3.66–3.62 (m, 2H), 2.98–2.93 (m, 2H), 2.77 (t, <i>J</i> = 6.0 Hz, 2H), 2.61–2.57 (m, 8H), 2.52–2.43 (m, 1H), 1.80 (t, <i>J</i> = 6.6 Hz, 4H), 1.61–1.50 (m, 2H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −118.31 ppm; LC–MS <i>m</i>/<i>z</i> 456 (M + 1).</div></div><div id="sec4.1.23" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3847">6-Chloro-2-(4-morpholinopiperidin-1-yl)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>24</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = Cl) (0.2 mmol, 70 mg), yellow solid. Yield, 31% (28 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.97 (d, <i>J</i> = 2.2 Hz, 1H), 7.65 (d, <i>J</i> = 8.8 Hz, 1H), 7.50 (dd, <i>J</i> = 2.4, 8.8 Hz, 1H), 7.15 (s, 1H), 6.63–6.63 (m, 1H), 4.59 (d, <i>J</i> = 13.2 Hz, 2H), 3.75 (t, <i>J</i> = 4.6 Hz, 4H), 3.66 (q, <i>J</i> = 5.6 Hz, 2H), 3.05–2.98 (m, 2H), 2.78 (dd, <i>J</i> = 5.8, 5.8 Hz, 2H), 2.63- 2.58 (m, 8H), 2.53–2.47 (m, 1H), 2.00 (d, <i>J</i> = 12.5 Hz, 2H), 1.82 (dd, <i>J</i> = 3.2, 6.5 Hz, 4H), 1.65–1.53 (m, 2H) ppm; LC–MS <i>m</i>/<i>z</i> 473 (M + 1).</div></div><div id="sec4.1.24" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3905">6-Fluoro-2-((3-morpholinopropyl)amino)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>25</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = F) (0.75 mmol, 241 mg), off white solid. Yield, 34% (110 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.52–7.48 (m, 2H), 7.19–7.16 (m 1H), 6.36–6.35 (m 1H), 6.02 (s, 1H), 3.64 (br s, 4H), 3.56 (q, <i>J</i> = 5.6 Hz, 2H), 3.22 (br s, 2H), 2.70 (t, <i>J</i> = 5.9 Hz, 2H), 2.53 (br s, 4H), 2.35 (br s, 6H), 1.71 (br s, 4H), 1.65 (br s, 2H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −119.32 ppm; LC–MS <i>m</i>/<i>z</i> 430 (M + 1).</div></div><div id="sec4.1.25" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3947">6-Fluoro-2-((3-morpholinoethyl)amino)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>26</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = F) (0.3 mmol, 88 mg), yellow solid. Yield, 29% (33 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.69–7.65 (m, 2H), 7.31 (ddd, <i>J</i> = 2.9, 8.2, 9.1 Hz, 1H), 6.91–6.89 (m, 1H), 6.76 (s, 1H), 3.74 (dd, <i>J</i> = 4.6, 4.6 Hz, 4H), 3.65–3.53 (m, 4H), 2.75 (t, <i>J</i> = 5.9 Hz, 2H), 2.66–2.55 (m, 6H), 2.54–2.48 (m, 4H), 1.81–1.79 (m, 4H)ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −118.87 ppm; LC–MS <i>m</i>/<i>z</i> 416 (M + 1).</div></div><div id="sec4.1.26" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e3992">6-Chloro-2-((4-morpholinobutyl)amino)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>27</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = Cl) (0.3 mmol, 100 mg), white solid. Yield, 54% (50 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.97 (d, <i>J</i> = 20.4 Hz, 1H), 7.61 (d, <i>J</i> = 9.0 Hz, 1H), 7.49 (dd, <i>J</i> = 2.4, 9.0 Hz, 1H), 6.82 (s, 1H), 6.66 (s, 1H), 3.75 (t, <i>J</i> = 4.7 Hz, 4H), 3.68–3.63 (m, 2H), 3.44 (q, <i>J</i> = 6.2 Hz, 2H), 2.78 (t, <i>J</i> = 5.9 Hz, 2H), 2.62 (br s, 4H), 2.48–2.39 (m, 8H), 1.84–1.79 (m, 4H), 1.73–1.61 (m, 2H) ppm; LC–MS <i>m</i>/<i>z</i> 460 (M + 1).</div></div><div id="sec4.1.27" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4041">6-Fluoro-2-((2-(piperidin-1-yl)amino)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>28</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = F) (0.26 mmol, 84 mg), off white solid. Yield, 9% (10 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.61–7.57 (m, 2H), 7.26 (ddd, <i>J</i> = 3.0, 8.6, 8.6 Hz, 1H), 6.70 (s, 1H), 6.67 (s, 1H), 5.44–5.42 (m, 1H), 3.57–3.44 (m, 4H), 2.66 (dd, <i>J</i> = 6.0, 6.0 Hz, 2H), 2.53–2.47 (m, 4H), 2.44–2.28 (m, 6H), 1.74–1.69 (m, 4H), 1.54–1.45 (m, 5H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −119.16 ppm; LC–MS <i>m</i>/<i>z</i> 414 (M + 1).</div></div><div id="sec4.1.28" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4083">6-Fluoro-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)-2-((2-(tetrahydro-2<i>H</i>-pyran-4-yl)ethyl)amino)quinoline-4-carboxamide (<b>29</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = F) (0.32 mmol, 100 mg), white solid. Yield, 7% (6 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 7.61–7.55 (m, 2H), 7.23 (ddd, <i>J</i> = 2.4, 7.8, 9.7 Hz, 1H), 6.75 (br s, 1H), 6.59 (s, 1H), 4.74 (br s, 1H), 3.89 (dd, <i>J</i> = 3.8, 11.2 Hz, 2H), 3.55 (q, <i>J</i> = 5.6 Hz, 2H), 3.39–3.27 (m, 4H), 2.68 (t, <i>J</i> = 5.9 Hz, 2H), 2.50 (d, <i>J</i> = 5.4 Hz, 4H), 1.74–1.69 (m, 4H), 1.62–1.48 (m, 5H), 1.33–1.21 (m, 2H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −118.84 ppm; LC–MS <i>m</i>/<i>z</i> 415 (M + 1).</div></div><div id="sec4.1.29" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4138">6-Chloro-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)-2-((2-(tetrahydro-2<i>H</i>-pyran-4-yl)ethyl)amino)quinoline-4-carboxamide (<b>30</b>)</span><div class="NLM_p last">Prepared using general procedure C starting from <b>5</b> (R<sup>1</sup> = Cl) (1.5 mmol, 500 mg), yellow solid. Yield, 31% (200 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.06 (br s, 1H), 8.05 (d, <i>J</i> = 2 0.4 Hz, 1H), 7.51 (d, <i>J</i> = 9.0 Hz, 1H), 7.37 (dd, <i>J</i> = 2.4, 8.8 Hz, 1H), 7.17 (m, 1H), 4.94 (t, <i>J</i> = 5.0 Hz, 1H), 3.88 (dd, <i>J</i> = 3.8, 11.2 Hz, 2H), 3.74 (q, <i>J</i> = 5.4 Hz, 2H), 3.46 (q, <i>J</i> = 6.6 Hz, 2H), 3.33–3.27 (m, 2H), 3.16–3.06 (m, 6H), 2.03–1.98 (m, 3H), 1.63–1.49 (m, 6H), 1.32–1.21 (m, 2H) ppm; LC–MS <i>m</i>/<i>z</i> 431 (M + 1).</div></div><div id="sec4.1.30" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4193">General Procedure D: Suzuki Coupling on Intermediate <b>5</b></span><div class="NLM_p last">To a solution of <b>5</b> (1 equiv) in DMF/water 3/1 (4 mL) in a microwave vial were added potassium phosphate (3 equiv), the corresponding boronic acid (3 equiv), and Pd(PPh<sub>3</sub>)<sub>4</sub> (3 mol %). The reaction was degassed by bubbling nitrogen through the mixture for 5 min and then heated under microwave irradiation at 130 °C for 30 min. Reaction mixture was filtered through Celite. Celite was washed with DCM. Filtrate was partitioned between water (5 mL) and DCM (25 mL × 2). Organic phase was dried over MgSO<sub>4</sub>, and solvents were evaporated under reduced pressure. Product was purified by column chromatography on 4 g silica cartridges using A (DCM) and B (20% MeOH–NH<sub>3</sub> in DCM) and the following gradient: 3 min hold 100% A, 15 min ramp to 30% B, 4 min hold at 30% B.</div></div><div id="sec4.1.31" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4215">2-(4-(Dimethylamino)phenyl)-6-fluoro-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>36</b>)</span><div class="NLM_p last">Prepared using general procedure D starting from <b>5</b> (R<sup>1</sup> = F) (0.2 mmol, 65 mg), yellow solid. Yield, 25% (20 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.13–8.07 (m, 3H), 7.91–7.87 (m, 2H), 7.47 (ddd, <i>J</i> = 2.9, 8.1, 9.2 Hz, 1H), 6.96 (s, 1H), 6.85–6.82 (m, 2H), 3.70 (q, <i>J</i> = 5.7 Hz, 2H), 3.08 (s, 6H), 2.83 (t, <i>J</i> = 6.0 Hz, 2H), 2.67–2.64 (m, 4H), 1.86–1.81 (m, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −113.18 ppm; LC–MS <i>m</i>/<i>z</i> 407 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.32" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4264">6-Fluoro-2-(4-morpholinophenyl)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>37</b>)</span><div class="NLM_p last">Prepared using general procedure D starting from <b>5</b> (R<sup>1</sup> = F) (0.5 mmol, 150 mg), yellow solid. Yield, 19% (43 mg); <sup>1</sup>H NMR (500 MHz, CDCl3) δ 8.15–8.07 (m, 3H), 7.91–7.87 (m, 2H), 7.52–7.47 (m, 1H), 7.03 (d, <i>J</i> = 8.8 Hz, 2H), 6.89 (t, <i>J</i> = 4.5 Hz, 1H), 3.92 (t, <i>J</i> = 4.8 Hz, 4H), 3.68 (q, <i>J</i> = 5.7 Hz, 2H), 3.30 (t, <i>J</i> = 4.8 Hz, 4H), 2.79 (t, <i>J</i> = 6.0 Hz, 2H), 2.60–2.62 (m, 4H), 1.81 (t, <i>J</i> = 3.3 Hz, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −112.39 ppm; LC–MS <i>m</i>/<i>z</i> 449 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.33" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4323">6-Fluoro-2-(4-(morpholinosulfonyl)phenyl)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>38</b>)</span><div class="NLM_p last">Prepared using general procedure D starting from <b>5</b> (R<sup>1</sup> = F) (0.23 mmol, 75 mg), white solid. Yield, 20% (24 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.36–8.33 (m, 2H), 8.22 (dd, <i>J</i> = 5.4, 9.2 Hz, 1H), 8.04–7.99 (m, 2H), 7.91 (d, <i>J</i> = 8.5 Hz, 2H), 7.58 (ddd, <i>J</i> = 2.8, 8.0, 9.2 Hz, 1H), 6.98 (s, 1H), 3.79–3.69 (m, 6H), 3.07 (t, <i>J</i> = 4.7 Hz, 4H), 2.81 (t, <i>J</i> = 5.9 Hz, 2H), 2.62 (d, <i>J</i> = 5.4 Hz, 4H), 1.84–1.79 (m, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −109.76 ppm; LC–MS <i>m</i>/<i>z</i> 513 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.34" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4381">6-Fluoro-2-(4-(morpholine-4-carbonyl)phenyl)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>39</b>)</span><div class="NLM_p last">Prepared using general procedure D starting from <b>5</b> (R<sup>1</sup> = F) (0.25 mmol, 80 mg), yellow solid. Yield, 73% (87 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.18–8.14 (m, 3H), 7.96–7.94 (m, 2H), 7.54–7.50 (m, 3H), 7.10 (dd, J = 4.9, 4.9 Hz, 1H), 3.76–3.72 (m, 6H), 3.69–3.66 (m, 4H), 2.78 (t, <i>J</i> = 6.0 Hz, 2H), 2.61–2.59 (m, 4H), 1.81–1.79 (m, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −110.76 ppm; LC–MS <i>m</i>/<i>z</i> 477 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.35" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4423">1-(4-(Bromomethyl)-2-chlorophenyl)ethanone (<b>7</b>)</span><div class="NLM_p last">A mixture of 1-(2-chloro-4-methylphenyl)ethanone (1.6 g, 9.50 mmol) and chlorobenzene (60 mL) was prepared at rt and <i>N</i>-bromosuccinimide (NBS) (1.86 g, 10.44 mmol) added followed by benzoyl peroxide (∼1.5 mg, 0.005 mmol, catalytic amount), and the mixture was heated to 140–145 °C for 16 h. The mixture was then cooled to rt, diluted with toluene (50 mL), and filtered through a Celite pad. The pad was washed with toluene (2 × 50 mL) and the filtrate concentrated under reduced pressure and purified by column chromatography (0–10% EtOAc/hexanes) to afford 1-(4-(bromomethyl)-2-chlorophenyl)ethanone (1.65 g, 6.65 mmol, 70%) as a yellow oil. <sup>1</sup>H NMR (500 MHz; CDCl<sub>3</sub>) δ 2.65 (s, 3H), 4.43 (s, 2H), 7.34 (dd, 1H, <i>J</i> = 1.3, 8.0 Hz), 7.46 (s, 1H), 7.54 (d, 1H, <i>J</i> = 7.9 Hz) ppm.</div></div><div id="sec4.1.36" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4446">1-(2-Chloro-4-(morpholinomethyl)phenyl)ethanone (<b>8</b>, X = Cl)</span><div class="NLM_p last">A mixture of 1-(4-(bromomethyl)-2-chlorophenyl)ethanone (1.65 g, 6.65 mmol) and acetonitrile (25 mL) was prepared at rt and stirred under nitrogen. Potassium carbonate (1.10g 7.98 mmol) was then added followed by morpholine (0.695 mL, 695 mg, 7.98 mmol), and the mixture was stirred at rt. After 2 h, TLC showed presence of product and starting material. Mixture was then heated under nitrogen to 40 °C for 16 h, cooled to room temp, filtered to remove excess carbonate and filtrate concentrated under reduced pressure. Mixture was then diluted in DCM (30 mL), washed with water (2 × 10 mL), filtered through a phase separator and filtrate concentrated under reduced pressure. Mixture was purified by column chromatography (40–100% ethyl acetate/hexane) to afford 1-(2-chloro-4-(morpholinomethyl)phenyl)ethanone (1.08 g, 4.25 mmol, 64%) as a yellow oil. <sup>1</sup>H NMR (500 MHz; CDCl<sub>3</sub>) δ 2.44 (brs, 4H), 2.65 (s, 3H), 3.49 (s, 2H), 3.72 (t, <i>J</i> = 4.6 Hz, 4H), 7.29 (dd, <i>J</i> = 1.5, 7.9 Hz, 1H,), 7.43 (brs, 1H), 7.55 (d, <i>J</i> = 7.9 Hz, 1H) ppm; LCMS <i>m</i>/<i>z</i> 254 [M + H]<sup>+</sup></div></div><div id="sec4.1.37" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4478">2-(2-Chloro-4-(morpholinomethyl)phenyl)-6-fluoroquinoline-4-carboxylic Acid (<b>9</b>, X = Cl)</span><div class="NLM_p last">A mixture of 5-fluoroisatin (7.02 mg, 4.25 mmol) and 1-(2-chloro-4-(morpholinomethyl)phenyl)ethanone (1.08 g, 4.25 mmol) was prepared in EtOH/water (1:1) (10 mL) and then KOH (2.40 g, 42.50 mmol) added and the mixture heated in microwave, 125 °C, 20 min. The mixture was then diluted with water (10 mL), acidified to pH 3 with 2 M HCl, stirred for 16 h at rt and the resulting precipitate filtered, washed with water (2 × 10 mL), and concentrated under reduced pressure to afford 2-(2-chloro-4-(morpholinomethyl)phenyl)-6-fluoroquinoline-4-carboxylic acid (503 mg, 1.25 mmol, 30%) as an orange solid. <sup>1</sup>H NMR (500 MHz; CDCl<sub>3</sub>) δ 2.54 (brs, 4H), 3.64 (s, 4H), 3.70 (brs, 2H), 7.50 (d, <i>J</i> = 8.1 Hz, 1H), 7.62 (s, 1H), 7.73 (bd, <i>J</i> = 7.9 Hz, 1H), 7.84 (dt, <i>J</i> = 2.9, 8.2 Hz, 1H,), 8.24 (dd, <i>J</i> = 5.8, 9.2 Hz, 1H), 8.56 (dd, <i>J</i> = 2.9, 11.0 Hz, 1H) ppm; LCMS <i>m</i>/<i>z</i> 399 [M – H]<sup>−</sup>.</div></div><div id="sec4.1.38" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4517">2-(2-Chloro-4-(morpholinomethyl)phenyl)-6-fluoro-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>42</b>)</span><div class="NLM_p last">A mixture of 2-(2-chloro-4-(morpholinomethyl)phenyl)-6-fluoroquinoline-4-carboxylic acid (303 mg, 0.76 mmol) in DCM (6 mL) was prepared at rt, and <i>N</i>-methylmorpholine (0.166 mL, 153 mg, 1.51 mmol) and 2-chloro-4,6-dimethoxy-1,3,5-triazine (CDMT) (159 mg, 0.91 mmol) were added, and the mixture was stirred for 1 h in a sealed vial. 2-(Pyrrolidin-1-yl)ethanamine (0.143 mL, 130 mg, 1.13 mmol) was then added and the mixture stirred in a sealed vial for 17 h. The mixture was then diluted with DCM (5 mL), and the organic layers were washed with water (2 × 3 mL) and filtered through a phase separator and the organic layers concentrated under reduced pressure and purified by column chromatography (0–10% 7 M NH<sub>3</sub> in MeOH/DCM) to afford an off white solid. Analysis by <sup>1</sup>H NMR showed impurities, and the mixture was further purified by MDAP to produce 2-(2-chloro-4-(morpholinomethyl)phenyl)-6-fluoro-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (228 mg, 0.46 mmol, 61%) as an off-white solid. <sup>1</sup>H NMR (500 MHz; CDCl3) δ 1.76–1.79 (m, 4H), 2.49 (brs, 4H), 2.57 (brs, 4H), 2.75 (t, <i>J</i> = 6.0 Hz, 2H), 3.55 (s, 2H), 3.65 (q, <i>J</i> = 5.3 Hz, 2H), 3.74 (t, <i>J</i> = 4.6 Hz, 4H), 6.82 (brs, 1H), 7.40 (dd, <i>J</i> = 1.6, 7.9 Hz, 1H), 7.52–7.57 (m, 2H), 7.68 (d, <i>J</i> = 7.9 Hz, 1H), 7.89 (s, 1H), 8.05 (dd, <i>J</i> = 2.8, 10.0 Hz, 1H), 8.19 (dd, <i>J</i> = 5.5, 9.2 Hz, 1H) ppm; LCMS <i>m</i>/<i>z</i> 497 [M + H]<sup>+</sup>.</div></div><div id="sec4.1.39" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4575">6-Fluoro-<i>N</i>-(2-morpholinoethyl)-2-(4-morpholinomethyl)phenyl)quinoline-4-carboxamide (<b>46</b>)</span><div class="NLM_p last">A solution of 6-fluoro-2-(4-(morpholinomethyl)phenyl)quinoline-4-carboxylic acid (<b>9</b>, X = H)<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> (0.1 g, 0.27 mmol), 2-chloro-4,6-dimethoxy-1,3,5-triazine CDMT (57 mg, 0.32 mmol, 1.2 equiv), and <i>N</i>-methylmorpholine (0.06 mL, 0.54 mmol, 2 equiv) in DCM (10 mL) was stirred at room temperature for 1 h. 2-Morpholinoethanamide (0.054 mL, 0.41 mmol, 1.5 equiv) was added, and the reaction mixture was stirred at room temperature overnight. Reaction was partitioned between DCM (50 mL) and NaHCO<sub>3</sub> sat. aq solution (10 mL). Organic phase was dried over MgSO<sub>4</sub>, and solvents were removed under reduce pressure. Product precipitated from acetonitrile (1.5 mL) as a white solid. Yield, 63% (83 mg); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.22 (dd, <i>J</i> = 5.4, 9.2 Hz, 1H), 8.12 (d, <i>J</i> = 8.2 Hz, 2H), 8.00–7.97 (m, 2H), 7.58–7.52 (m, 3H), 6.67 (t, <i>J</i> = 4.8 Hz, 1H), 3.77–3.70 (m, 10H), 3.61 (s, 2H), 2.70 (t, <i>J</i> = 5.9 Hz, 2H), 2.57 (br s, 4H), 2.51 (t, <i>J</i> = 4.3 Hz, 4H) ppm; <sup>19</sup>F NMR (407.5 MHz; CDCl<sub>3</sub>) δ −111.23; LC–MS <i>m</i>/<i>z</i> 479 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.40" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4639">6-Fluoro-<i>N</i>-methyl-2-(4-(morpholinomethyl)phenyl)-<i>N</i>-(2-(pyrrolidin-1-yl)ethyl)quinoline-4-carboxamide (<b>47</b>)</span><div class="NLM_p last">To a suspension of 6-fluoro-2-[4-(morpholinomethyl)phenyl]quinoline-4-carboxylic acid (<b>9</b>, X = H)<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> (100 mg, 0.27 mmol) in anhydrous DCM (10 mL) were added <i>N</i>-methylmorpholine (0.06 mL, 0.54 mmol, 2 equiv) and 2-chloro-4,6-dimethoxy-1,3,5-triazine CDMT (57 mg, 0.32 mmol, 1.2 equiv). The reaction mixture was stirred at room temperature for 1 h. <i>N</i>-Methyl-2-pyrrolidin-1-ylethanamine (0.034 g, 0.27 mmol) was added and the reaction mixture stirred at room temperature overnight. The mixture was then diluted with DCM (10 mL), water (10 mL) was added, and the layers were separated. The aqueous portion was extracted with further DCM (10 mL). The combined DCM extracts were evaporated in vacuo. The residue was dissolved in DMF and purified by mass directed autoprep 5–95% MeCN, basic, to afford impure product. The sample was dissolved in DMF and purified using mass directed autoprep 25–75% MeCN, basic, and the product obtained was freeze-dried to afford <b>47</b> as a cream colored solid (24 mg, 17% yield); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.15–8.08 (m, 3H), 8.04–8.01 (m, 1H), 7.48–7.42 (m, 3H), 7.36 (dd, <i>J</i> = 2.8, 9.2 Hz, 1H), 4.06–4.03 (m, 1H), 3.67 (dd, <i>J</i> = 4.3, 4.3 Hz, 4H), 3.53 (s, 2H), 3.27 (s, 2H), 3.22 (s, 1H), 2.90 (s, 3H), 2.43 (s, 4H), 2.11- 2.06 (m, 4H), 1.81–1.51 (m, 4H) ppm; LC–MS <i>m</i>/<i>z</i> 477 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.41" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4691"><i>N</i>-(2-(Cyclopropylamino)ethyl)-6-fluoro-2-(4-(morpholinomethyl)phenyl)quinoline-4-carboxamide (<b>48</b>)</span><div class="NLM_p last">To a suspension of 6-fluoro-2-[4-(morpholinomethyl)phenyl]quinoline-4-carboxylic acid (<b>9</b>, X = H)<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> (0.1 g, 0.27 mmol) in anhydrous DCM (10 mL) were added <i>N</i>-methylmorpholine (0.06 mL, 0.54 mmol, 2 equiv) and 2-chloro-4,6-dimethoxy-1,3,5-triazine CDMT (57 mg, 0.32 mmol, 1.2 equiv). The reaction mixture was stirred at room temperature for 1 h. <i>N</i>′-Cyclopropylethane-1,2-diamine (0.027 g,0.27 mmol) was added and the reaction mixture stirred at room temperature for 2.5 days. The mixture was then diluted with DCM (10 mL), water (10 mL) was added, and the layers were separated. The aqueous portion was extracted with further DCM (10 mL). The combined DCM extracts were evaporated in vacuo. The residue was dissolved in DMF and purified by mass directed autoprep 5–95% MeCN, basic, method to afford <b>48</b> as a yellow solid (25 mg, 18% yield); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.18 (dd, <i>J</i> = 5.4, 9.2 Hz, 1H), 8.09 (d, <i>J</i> = 8.2 Hz, 2H), 7.94–7.91 (m, 2H), 7.55–7.49 (m, 3H), 6.74–6.72 (m, 1H), 3.75–3.66 (m, 6H), 3.59 (s, 2H), 3.06 (t, <i>J</i> = 5.8 Hz, 2H), 2.49 (s, 4H), 2.23–2.18 (m, 1H), 0.54–0.49 (m, 2H), 0.39–0.35 (m, 2H); LC–MS <i>m</i>/<i>z</i> 449 (M + H)<sup>+</sup>.</div></div><div id="sec4.1.42" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4742"><i>N</i>-(2-(Azetidin-1-yl)ethyl)-6-fluoro-2-(4-(morpholinomethyl)phenyl)quinoline-4-carboxamide (<b>49</b>)</span><div class="NLM_p">To a suspension of 6-fluoro-2-[4-(morpholinomethyl)phenyl]quinoline-4-carboxylic acid (<b>9</b>, X = H)<a onclick="showRef(event, 'ref5'); return false;" href="JavaScript:void(0);" class="ref">(5)</a> (100 mg,0.27 mmol) in anhydrous DCM (10 mL) were added <i>N</i>-methylmorpholine (0.06 mL, 0.54 mmol, 2 equiv) and 2-chloro-4,6-dimethoxy-1,3,5-triazine CDMT (57 mg, 0.32 mmol, 1.2 equiv). The reaction mixture was stirred at room temperature for 1 h. 2,2-Dimethoxyethanamine (28 mg,0.27 mmol) was added and the reaction mixture stirred at room temperature for 2.5 days. The mixture was then diluted with DCM (10 mL), water (10 mL) was added, and the layers were separated. The aqueous portion was extracted with further DCM (10 mL). The combined DCM extracts were evaporated in vacuo. The residue was dissolved in DCM and purified by silica (12 g), eluting with 0–100% EtOAc/hexane and then 0–50% (10% MeOH in DCM/DCM) to afford <i>N</i>-(2,2-dimethoxyethyl)-6-fluoro-2-[4-(morpholinomethyl)phenyl]quinoline-4-carboxamide as a yellow gum (109 mg, 79% yield). A solution of <i>N</i>-(2,2-dimethoxyethyl)-6-fluoro-2-[4-(morpholinomethyl)phenyl]quinoline-4-carboxamide (109 mg,0.24 mmol) in 1,4-dioxane (5 mL) was treated with conc. HCl (1 mL) and stirred at room temperature for 1.5 h. The mixture was neutralized with saturated sodium bicarbonate portionwise and then exracted with EtOAc (2 × 20 mL). The combined EtOAc extracts were evaporated in vacuo to afford 6-fluoro-2-[4-(morpholinomethyl)phenyl]-<i>N</i>-(2-oxoethyl)quinoline-4-carboxamide as a yellow gum (78 mg, 71% yield). A mixture of 6-fluoro-2-[4-(morpholinomethyl)phenyl]-<i>N</i>-(2-oxoethyl)quinoline-4-carboxamide (78 mg,0.19 mmol), azetidine (32 mg,0.57 mmol) in DCM (5 mL) was stirred for 15 min in a stoppered flask at room temperature. Sodium triacetoxyborohydride (56 mg,0.26 mmol) was then added, and the reaction mixture was stirred at room temperature overnight. The reaction mixture was partitioned between water (10 mL) and DCM (10 mL) and the aqueous extracted with further DCM (10 mL). The combined DCM extracts were evaporated in vacuo. The residue was dissolved in DMF and purified by mass directed autoprep, 5–95% MeCN, basic, to afford a yellow gum. The sample was freeze-dried to afford <b>49</b> as a cream colored solid (18 mg, 14% yield); <sup>1</sup>H NMR (500 MHz, CDCl<sub>3</sub>) δ 8.21 (dd, <i>J</i> = 5.4, 9.2 Hz, 1H), 8.13 (d, <i>J</i> = 8.4 Hz, 2H), 8.00–7.97 (m, 2H), 7.58–7.52 (m, 3H), 6.73–6.72 (m, 1H), 3.76 (t, <i>J</i> = 4.6 Hz, 4H), 3.61 (s, 2H), 3.57–3.53 (m, 2H), 3.28 (t, <i>J</i> = 7.0 Hz, 4H), 2.72 (t, <i>J</i> = 5.8 Hz, 2H), 2.51 (s, 4H), 2.14–2.07 (m, 2H); LC–MS <i>m</i>/<i>z</i> 449 (M + H)<sup>+</sup>.</div><div class="NLM_p last">Details of other synthetic routes for individual compounds are described in the <a href="http://pubs.acs.org/doi/suppl/10.1021/acs.jmedchem.6b00723/suppl_file/jm6b00723_si_001.pdf" class="ext-link">Supporting Information</a>.</div></div><div id="sec5" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4814">Biology Materials and Methods</span><div class="NLM_p last">This is included in the <a href="http://pubs.acs.org/doi/suppl/10.1021/acs.jmedchem.6b00723/suppl_file/jm6b00723_si_001.pdf" class="ext-link">Supporting Information</a>.</div></div><div id="sec6" class="NLM_sec NLM_sec_level_2"><span class="title2" id="d1564080e4823">Ethical Statements</span><div class="NLM_p">In vivo antimalarial efficacy studies in <i>P. berghei</i> carried out at the Swiss Tropical and Public Health Institute (Basel, Switzerland) adhere to local and national regulations of laboratory animal welfare in Switzerland (awarded Permission No. 1731). Protocols are regularly reviewed and revised following approval by the local authority (Veterinäramt Basel Stadt).</div><div class="NLM_p last">Mouse and rat pharmacokinetics were carried out at the University of Dundee. All regulated procedures on living animals were carried out under the authority of a license issued by the Home Office under the Animals (Scientific Procedures) Act 1986, as amended in 2012 (and in compliance with EU Directive EU/2010/63). License applications will have been approved by the University’s Ethical Review Committee (ERC) before submission to the Home Office. The ERC has a general remit to develop and oversee policy on all aspects of the use of animals on University premises and is a subcommittee of the University Court, its highest governing body.</div></div></div><div class="NLM_back"><div class="NLM_notes" id="notes-1"> <ul class="anchors"><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="_i61"><a href="/doi/suppl/10.1021/acs.jmedchem.6b00723">Supporting Information</a></h2><hr /><p class="last">The Supporting Information is available free of charge on the <a href="http://pubs.acs.org" class="ext-link">ACS Publications website</a> at DOI: <a href="http://pubs.acs.org/doi/abs/10.1021/acs.jmedchem.6b00723" class="ext-link">10.1021/acs.jmedchem.6b00723</a>.<ul class="NLM_list-list_type-label" id="silist"><li><p class="inline">Synthetic details for all compounds, supplementary data tables, additional information on ADMET and pharmacology (<a href="http://pubs.acs.org/doi/suppl/10.1021/acs.jmedchem.6b00723/suppl_file/jm6b00723_si_001.pdf" class="ext-link">PDF</a>)</p></li><li><p class="inline">Molecular formula strings and some data (<a href="http://pubs.acs.org/doi/suppl/10.1021/acs.jmedchem.6b00723/suppl_file/jm6b00723_si_002.csv" class="ext-link">CSV</a>)</p></li></ul></p></div><div class="NLM_notes" id="notes-2"><p class="first last">The authors declare no competing financial interest.</p></div><div class="ack" id="ACK-d49e5058-autogenerated"><ul class="anchors"><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="_i62">Acknowledgment</h2><hr /><p class="last">We acknowledge Medicines for Malaria Venture for financial support. The University of Dundee also acknowledges support from the Wellcome Trust (Grant 100476 and a Principal Research Fellowship to A.H.F.). We thank Christian Scheurer and Jolanda Kamber from the Swiss TPH for assistance in performing assays against the drug-resistant parasites and the in vivo (<i>Pb</i>) antimalarial assays.</p></div><div class="NLM_sec NLM_sec_level_1"><div class="NLM_p last"><table summary="" class="NLM_def-list" id="dl1"><tr><td colspan="2" class="NLM_title">Abbreviations Used</td></tr><tr><td class="NLM_term">ACT</td><td class="NLM_def"><p class="first last">artemisinin combination therapy</p></td></tr><tr><td class="NLM_term">CDMT</td><td class="NLM_def"><p class="first last">2-chloro-4,6-dimethoxy-1,3,5-triazine</p></td></tr><tr><td class="NLM_term">Cli</td><td class="NLM_def"><p class="first last">intrinsic clearance</p></td></tr><tr><td class="NLM_term">EDC</td><td class="NLM_def"><p class="first last"><i>N</i>-(3-dimethylaminopropyl)-<i>N</i>′-ethylcarbodiimide hydrochloride</p></td></tr><tr><td class="NLM_term">HOBt</td><td class="NLM_def"><p class="first last">hydroxybenzotriazole</p></td></tr><tr><td class="NLM_term">LELP</td><td class="NLM_def"><p class="first last">ligand-efficiency-dependent lipophilicity</p></td></tr><tr><td class="NLM_term">LLE</td><td class="NLM_def"><p class="first last">lipophilic ligand efficiency</p></td></tr><tr><td class="NLM_term">MMV</td><td class="NLM_def"><p class="first last">Medicines for Malaria Venture</p></td></tr><tr><td class="NLM_term"><i>P</i><sub>e</sub></td><td class="NLM_def"><p class="first last">permeability</p></td></tr><tr><td class="NLM_term">TCP</td><td class="NLM_def"><p class="first last">target candidate profile</p></td></tr><tr><td class="NLM_term">WHO</td><td class="NLM_def"><p class="first last">World Health Organization</p></td></tr></table></div></div><ul class="anchors"><li class="refQuivkViewLink"><a title="Open Reference QuickView" onclick="showRef(event); return false;" href="JavaScript:void(0);"><span>Reference QuickView</span></a></li><li><a title="Jump to a Section" onclick="showPulldown(this); return false;" href="JavaScript:void(0);" class="anchorIMG"></a><ul style="display: none;"><li><a onclick="hidePulldown(this);" title="Top of Page" href="#top"><span>Top of Page</span></a></li><li><a onclick="hidePulldown(this);" title="Abstract" href="#Abstract"><span>Abstract</span></a></li><li><a onclick="hidePulldown(this);" title="Introduction" href="#_i2"><span>Introduction</span></a></li><li><a onclick="hidePulldown(this);" title="Results and Discussion" href="#_i4"><span>Results and Discussion</span></a></li><li><a onclick="hidePulldown(this);" title="Conclusion" href="#_i15"><span>Conclusion</span></a></li><li><a onclick="hidePulldown(this);" title="Experimental Section" href="#_i16"><span>Experimental Section</span></a></li><li><a onclick="hidePulldown(this);" title="References" href="#_i65"><span>References</span></a></li></ul></li></ul><h2 id="_i65">References</h2><hr /><p>This article references 15 other publications.</p><ol id="references" class="useLabel"><li id="ref1"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref1');return false;" class="refNumLink">1. </a></strong><div class="NLM_citation" id="cit1">WHO.  <span class="citation_source-book">World Malaria Report 2015</span>; <span class="NLM_publisher-name">World Health Organization</span>,  <span class="NLM_year">2015</span>; 280 pp, <a href="http://www.who.int/malaria/publications/world-malaria-report-2015/report/en/" class="extLink">http://www.who.int/malaria/publications/world-malaria-report-2015/report/en/</a>.<div class="citationLinks"><div class="casRecord empty" id="cas_cit1R"><div class="casContent">There is no corresponding record for this reference.</div></div></div></div></div></li><li id="ref2"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref2');return false;" class="refNumLink">2. </a></strong><div class="NLM_citation" id="cit2"><span class="hlFld-ContribAuthor ">Bhatt<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Weiss<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. J.</span>; <span class="hlFld-ContribAuthor ">Cameron<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E.</span>; <span class="hlFld-ContribAuthor ">Bisanzio<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Mappin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Dalrymple<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>U.</span>; <span class="hlFld-ContribAuthor ">Battle<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. E.</span>; <span class="hlFld-ContribAuthor ">Moyes<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. L.</span>; <span class="hlFld-ContribAuthor ">Henry<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Eckhoff<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. A.</span>; <span class="hlFld-ContribAuthor ">Wenger<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. A.</span>; <span class="hlFld-ContribAuthor ">Briet<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>O.</span>; <span class="hlFld-ContribAuthor ">Penny<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. A.</span>; <span class="hlFld-ContribAuthor ">Smith<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. A.</span>; <span class="hlFld-ContribAuthor ">Bennett<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Yukich<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Eisele<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. P.</span>; <span class="hlFld-ContribAuthor ">Griffin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. T.</span>; <span class="hlFld-ContribAuthor ">Fergus<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. A.</span>; <span class="hlFld-ContribAuthor ">Lynch<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Lindgren<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span>; <span class="hlFld-ContribAuthor ">Cohen<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. M.</span>; <span class="hlFld-ContribAuthor ">Murray<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. L. J.</span>; <span class="hlFld-ContribAuthor ">Smith<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. L.</span>; <span class="hlFld-ContribAuthor ">Hay<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. I.</span>; <span class="hlFld-ContribAuthor ">Cibulskis<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. E.</span>; <span class="hlFld-ContribAuthor ">Gething<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. W.</span><span class="NLM_article-title">The effect of malaria control on Plasmodium falciparum in Africa between 2000 and 2015</span> <span class="citation_source-journal">Nature</span>  <span class="NLM_year">2015</span>,  <span class="NLM_volume">526</span>,  <span class="NLM_fpage">207</span>– <span class="NLM_lpage">211</span>, <span class="refDoi">DOI: 10.1038/nature15535</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref2/cit2&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1038%2Fnature15535" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref2/cit2&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=26375008" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref2/cit2&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC2MXhsFersLrN" title="">CAS</a></a>]<div class="casRecord" id="cas_cit2R"><div class="casContent"><span class="casTitleNuber">2. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">The effect of malaria control on Plasmodium falciparum in Africa between 2000 and 2015</cas:atitle></div><div class="casAuthors">Bhatt, S.; Weiss, D. J.; Cameron, E.; Bisanzio, D.; Mappin, B.; Dalrymple, U.; Battle, K. E.; Moyes, C. L.; Henry, A.; Eckhoff, P. A.; Wenger, E. A.; Briet, O.; Penny, M. A.; Smith, T. A.; Bennett, A.; Yukich, J.; Eisele, T. P.; Griffin, J. T.; Fergus, C. A.; Lynch, M.; Lindgren, F.; Cohen, J. M.; Murray, C. L. J.; Smith, D. L.; Hay, S. I.; Cibulskis, R. E.; Gething, P. W.</div><div class="citationInfo"><span class="NLM_cas:title">Nature (London, United Kingdom)</span>
+        (<span class="NLM_cas:date">2015</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">526</cas:volume>
+        (<span class="NLM_cas:issue">7572</span>),
+    <span class="NLM_cas:pages">207-211</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">NATUAS</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">0028-0836</span>.
+    
+            (<span class="NLM_cas:orgname">Nature Publishing Group</span>)
+        </div><div class="casAbstract">Since the year 2000, a concerted campaign against malaria has led to unprecedented levels of intervention coverage across sub-Saharan Africa.  Understanding the effect of this control effort is vital to inform future control planning.  However, the effect of malaria interventions across the varied epidemiol. settings of Africa remains poorly understood owing to the absence of reliable surveillance data and the simplistic approaches underlying current disease ests.  Here we link a large database of malaria field surveys with detailed reconstructions of changing intervention coverage to directly evaluate trends from 2000 to 2015, and quantify the attributable effect of malaria disease control efforts.  We found that Plasmodium falciparum infection prevalence in endemic Africa halved and the incidence of clin. disease fell by 40% between 2000 and 2015.  We est. that interventions have averted 663 (542-753 credible interval) million clin. cases since 2000.  Insecticide-treated nets, the most widespread intervention, were by far the largest contributor (68% of cases averted).  Although still below target levels, current malaria interventions have substantially reduced malaria disease incidence across the continent.  Increasing access to these interventions, and maintaining their effectiveness in the face of insecticide and drug resistance, should form a cornerstone of post-2015 control strategies.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGrwpE0BNY1LmrVg90H21EOLACvtfcHk0lhcXv5dQxu-sg"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC2MXhsFersLrN&amp;md5=a6d38c412efb48432a0d1a4ec50c75fc</span></div></div></div></div></li><li id="ref3"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref3');return false;" class="refNumLink">3. </a></strong><div class="NLM_citation" id="cit3a">(a) <span class="hlFld-ContribAuthor ">Tun<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. M.</span>; <span class="hlFld-ContribAuthor ">Imwong<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Lwin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. M.</span>; <span class="hlFld-ContribAuthor ">Win<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. A.</span>; <span class="hlFld-ContribAuthor ">Hlaing<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. M.</span>; <span class="hlFld-ContribAuthor ">Hlaing<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T.</span>; <span class="hlFld-ContribAuthor ">Lin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K.</span>; <span class="hlFld-ContribAuthor ">Kyaw<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. P.</span>; <span class="hlFld-ContribAuthor ">Plewes<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K.</span>; <span class="hlFld-ContribAuthor ">Faiz<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. A.</span>; <span class="hlFld-ContribAuthor ">Dhorda<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Cheah<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. Y.</span>; <span class="hlFld-ContribAuthor ">Pukrittayakamee<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Ashley<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. A.</span>; <span class="hlFld-ContribAuthor ">Anderson<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. J.</span>; <span class="hlFld-ContribAuthor ">Nair<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">McDew-White<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Flegg<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. A.</span>; <span class="hlFld-ContribAuthor ">Grist<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. P.</span>; <span class="hlFld-ContribAuthor ">Guerin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Maude<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. J.</span>; <span class="hlFld-ContribAuthor ">Smithuis<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span>; <span class="hlFld-ContribAuthor ">Dondorp<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. M.</span>; <span class="hlFld-ContribAuthor ">Day<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. P.</span>; <span class="hlFld-ContribAuthor ">Nosten<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span>; <span class="hlFld-ContribAuthor ">White<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. J.</span>; <span class="hlFld-ContribAuthor ">Woodrow<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. J.</span><span class="NLM_article-title">Spread of artemisinin-resistant Plasmodium falciparum in Myanmar: a cross-sectional survey of the K13 molecular marker</span> <span class="citation_source-journal">Lancet Infect. Dis.</span>  <span class="NLM_year">2015</span>,  <span class="NLM_volume">15</span>,  <span class="NLM_fpage">415</span>– <span class="NLM_lpage">421</span>, <span class="refDoi">DOI: 10.1016/S1473-3099(15)70032-0</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref3/cit3a&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1016%2FS1473-3099%2815%2970032-0" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref3/cit3a&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=25704894" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref3/cit3a&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC2MXjtFShtr8%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit3aR"><div class="casContent"><span class="casTitleNuber">3a. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Spread of artemisinin-resistant Plasmodium falciparum in Myanmar: a cross-sectional survey of the K13 molecular marker</cas:atitle></div><div class="casAuthors">Tun, Kyaw M.; Imwong, Mallika; Lwin, Khin M.; Win, Aye A.; Hlaing, Tin M.; Hlaing, Thaung; Lin, Khin; Kyaw, Myat P.; Plewes, Katherine; Abul Faiz, M.; Dhorda, Mehul; Cheah, Phaik Yeong; Pukrittayakamee, Sasithon; Ashley, Elizabeth A.; Anderson, Tim J. C.; Nair, Shalini; McDew-White, Marina; Flegg, Jennifer A.; Grist, Eric P. M.; Guerin, Philippe; Maude, Richard J.; Smithuis, Frank; Dondorp, Arjen M.; Day, Nicholas P. J.; Nosten, Francois; White, Nicholas J.; Woodrow, Charles J.</div><div class="citationInfo"><span class="NLM_cas:title">Lancet Infectious Diseases</span>
+        (<span class="NLM_cas:date">2015</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">15</cas:volume>
+        (<span class="NLM_cas:issue">4</span>),
+    <span class="NLM_cas:pages">415-421</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">LIDABP</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1473-3099</span>.
+    
+            (<span class="NLM_cas:orgname">Elsevier Ltd.</span>)
+        </div><div class="casAbstract">Emergence of artemisinin resistance in southeast Asia poses a serious threat to the global control of Plasmodium falciparum malaria.  Discovery of the K13 marker has transformed approaches to the monitoring of artemisinin resistance, allowing introduction of mol. surveillance in remote areas through anal. of DNA.  We aimed to assess the spread of artemisinin-resistant P falciparum in Myanmar by detg. the relative prevalence of P falciparum parasites carrying K13-propeller mutations.  We did this cross-sectional survey at malaria treatment centers at 55 sites in ten administrative regions in Myanmar, and in relevant border regions in Thailand and Bangladesh, between Jan., 2013, and Sept., 2014.  K13 sequences from P falciparum infections were obtained mainly by passive case detection.  We entered data into two geostatistical models to produce predictive maps of the estd. prevalence of mutations of the K13 propeller region across Myanmar.  Overall, 371 (39%) of 940 samples carried a K13-propeller mutation.  We recorded 26 different mutations, including nine mutations not described previously in southeast Asia.  In seven (70%) of the ten administrative regions of Myanmar, the combined K13-mutation prevalence was more than 20%.  Geospatial mapping showed that the overall prevalence of K13 mutations exceeded 10% in much of the east and north of the country.  In Homalin, Sagaing Region, 25 km from the Indian border, 21 (47%) of 45 parasite samples carried K13-propeller mutations.  Artemisinin resistance extends across much of Myanmar.  We recorded P falciparum parasites carrying K13-propeller mutations at high prevalence next to the northwestern border with India.  Appropriate therapeutic regimens should be tested urgently and implemented comprehensively if spread of artemisinin resistance to other regions is to be avoided.  Wellcome Trust-Mahidol University-Oxford Tropical Medicine Research Program and the Bill &amp; Melinda Gates Foundation.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGoxQkC32mnG17Vg90H21EOLACvtfcHk0lhcXv5dQxu-sg"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC2MXjtFShtr8%253D&amp;md5=2a8f63354ba261347cd0d8b95ed03743</span></div></div></div><div class="NLM_citation" id="cit3b">(b) <span class="hlFld-ContribAuthor ">Phyo<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. P.</span>; <span class="hlFld-ContribAuthor ">Nkhoma<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Stepniewska<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K.</span>; <span class="hlFld-ContribAuthor ">Ashley<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. A.</span>; <span class="hlFld-ContribAuthor ">Nair<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">McGready<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">ler Moo<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C.</span>; <span class="hlFld-ContribAuthor ">Al-Saai<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Dondorp<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. M.</span>; <span class="hlFld-ContribAuthor ">Lwin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. M.</span>; <span class="hlFld-ContribAuthor ">Singhasivanon<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Day<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. P.</span>; <span class="hlFld-ContribAuthor ">White<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. J.</span>; <span class="hlFld-ContribAuthor ">Anderson<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. J.</span>; <span class="hlFld-ContribAuthor ">Nosten<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span><span class="NLM_article-title">Emergence of artemisinin-resistant malaria on the western border of Thailand: a longitudinal study</span> <span class="citation_source-journal">Lancet</span>  <span class="NLM_year">2012</span>,  <span class="NLM_volume">379</span>,  <span class="NLM_fpage">1960</span>– <span class="NLM_lpage">1966</span>, <span class="refDoi">DOI: 10.1016/S0140-6736(12)60484-X</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref3/cit3b&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1016%2FS0140-6736%2812%2960484-X" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref3/cit3b&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=22484134" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref3/cit3b&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A280%3ADC%252BC38rjtFehsg%253D%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit3bR"><div class="casContent"><span class="casTitleNuber">3b. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Emergence of artemisinin-resistant malaria on the western border of Thailand: a longitudinal study</cas:atitle></div><div class="casAuthors">Phyo Aung Pyae; Nkhoma Standwell; Stepniewska Kasia; Ashley Elizabeth A; Nair Shalini; McGready Rose; ler Moo Carit; Al-Saai Salma; Dondorp Arjen M; Lwin Khin Maung; Singhasivanon Pratap; Day Nicholas P J; White Nicholas J; Anderson Tim J C; Nosten Francois</div><div class="citationInfo"><span class="NLM_cas:title">Lancet (London, England)</span>
+        (<span class="NLM_cas:date">2012</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">379</cas:volume>
+        (<span class="NLM_cas:issue">9830</span>),
+    <span class="NLM_cas:pages">1960-6</span>
+        ISSN:<span class="NLM_cas:issn"></span>.
+    </div><div class="casAbstract">BACKGROUND:  Artemisinin-resistant falciparum malaria has arisen in western Cambodia.  A concerted international effort is underway to contain artemisinin-resistant Plasmodium falciparum, but containment strategies are dependent on whether resistance has emerged elsewhere.  We aimed to establish whether artemisinin resistance has spread or emerged on the Thailand-Myanmar (Burma) border.  METHODS:  In malaria clinics located along the northwestern border of Thailand, we measured six hourly parasite counts in patients with uncomplicated hyperparasitaemic falciparum malaria (≥4% infected red blood cells) who had been given various oral artesunate-containing regimens since 2001.  Parasite clearance half-lives were estimated and parasites were genotyped for 93 single nucleotide polymorphisms.  FINDINGS:  3202 patients were studied between 2001 and 2010.  Parasite clearance half-lives lengthened from a geometric mean of 2·6 h (95% CI 2·5-2·7) in 2001, to 3·7 h (3·6-3·8) in 2010, compared with a mean of 5·5 h (5·2-5·9) in 119 patients in western Cambodia measured between 2007 and 2010.  The proportion of slow-clearing infections (half-life ≥6·2 h) increased from 0·6% in 2001, to 20% in 2010, compared with 42% in western Cambodia between 2007 and 2010.  Of 1583 infections genotyped, 148 multilocus parasite genotypes were identified, each of which infected between two and 13 patients.  The proportion of variation in parasite clearance attributable to parasite genetics increased from 30% between 2001 and 2004, to 66% between 2007 and 2010.  INTERPRETATION:  Genetically determined artemisinin resistance in P falciparum emerged along the Thailand-Myanmar border at least 8 years ago and has since increased substantially.  At this rate of increase, resistance will reach rates reported in western Cambodia in 2-6 years.  FUNDING:  The Wellcome Trust and National Institutes of Health.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=LOZGTtr2ZcQ9gTXdi_aNKUcLvDNbOD4DfW6udTcc2ea1Axw8-fIEDbntkvexoksv"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A280%3ADC%252BC38rjtFehsg%253D%253D&amp;md5=9de4b3f2862332e0bf33d1d6612b06d0</span></div></div></div><div class="NLM_citation" id="cit3c">(c) <span class="hlFld-ContribAuthor ">Takala-Harrison<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Jacob<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. G.</span>; <span class="hlFld-ContribAuthor ">Arze<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C.</span>; <span class="hlFld-ContribAuthor ">Cummings<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. P.</span>; <span class="hlFld-ContribAuthor ">Silva<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. C.</span>; <span class="hlFld-ContribAuthor ">Dondorp<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. M.</span>; <span class="hlFld-ContribAuthor ">Fukuda<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. M.</span>; <span class="hlFld-ContribAuthor ">Hien<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. T.</span>; <span class="hlFld-ContribAuthor ">Mayxay<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Noedl<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>H.</span>; <span class="hlFld-ContribAuthor ">Nosten<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span>; <span class="hlFld-ContribAuthor ">Kyaw<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. P.</span>; <span class="hlFld-ContribAuthor ">Nhien<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. T.</span>; <span class="hlFld-ContribAuthor ">Imwong<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Bethell<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Se<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>Y.</span>; <span class="hlFld-ContribAuthor ">Lon<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C.</span>; <span class="hlFld-ContribAuthor ">Tyner<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. D.</span>; <span class="hlFld-ContribAuthor ">Saunders<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. L.</span>; <span class="hlFld-ContribAuthor ">Ariey<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span>; <span class="hlFld-ContribAuthor ">Mercereau-Puijalon<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>O.</span>; <span class="hlFld-ContribAuthor ">Menard<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Newton<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. N.</span>; <span class="hlFld-ContribAuthor ">Khanthavong<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Hongvanthong<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Starzengruber<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Fuehrer<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>H. P.</span>; <span class="hlFld-ContribAuthor ">Swoboda<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Khan<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>W. A.</span>; <span class="hlFld-ContribAuthor ">Phyo<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. P.</span>; <span class="hlFld-ContribAuthor ">Nyunt<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. M.</span>; <span class="hlFld-ContribAuthor ">Nyunt<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. H.</span>; <span class="hlFld-ContribAuthor ">Brown<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. S.</span>; <span class="hlFld-ContribAuthor ">Adams<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Pepin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. S.</span>; <span class="hlFld-ContribAuthor ">Bailey<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Tan<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. C.</span>; <span class="hlFld-ContribAuthor ">Ferdig<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. T.</span>; <span class="hlFld-ContribAuthor ">Clark<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. G.</span>; <span class="hlFld-ContribAuthor ">Miotto<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>O.</span>; <span class="hlFld-ContribAuthor ">MacInnis<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Kwiatkowski<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. P.</span>; <span class="hlFld-ContribAuthor ">White<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. J.</span>; <span class="hlFld-ContribAuthor ">Ringwald<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Plowe<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. V.</span><span class="NLM_article-title">Independent emergence of artemisinin resistance mutations among Plasmodium falciparum in Southeast Asia</span> <span class="citation_source-journal">J. Infect. Dis.</span>  <span class="NLM_year">2015</span>,  <span class="NLM_volume">211</span>,  <span class="NLM_fpage">670</span>– <span class="NLM_lpage">679</span>, <span class="refDoi">DOI: 10.1093/infdis/jiu491</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref3/cit3c&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1093%2Finfdis%2Fjiu491" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref3/cit3c&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=25180241" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref3/cit3c&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A280%3ADC%252BC2M%252FntFGgsg%253D%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit3cR"><div class="casContent"><span class="casTitleNuber">3c. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Independent emergence of artemisinin resistance mutations among Plasmodium falciparum in Southeast Asia</cas:atitle></div><div class="casAuthors">Takala-Harrison Shannon; Jacob Christopher G; Nyunt Myaing M; Brown Tyler S; Adams Matthew; Pepin Christopher S; Bailey Jason; Plowe Christopher V; Arze Cesar; Silva Joana C; Cummings Michael P; Dondorp Arjen M; White Nicholas J; Fukuda Mark M; Bethell Delia; Tyner Stuart D; Saunders David L; Hien Tran Tinh; Nhien Nguyen Thanh Thuy; Mayxay Mayfong; Noedl Harald; Starzengruber Peter; Fuehrer Hans-Peter; Swoboda Paul; Nosten Francois; Kyaw Myat P; Nyunt Myat H; Imwong Mallika; Se Youry; Lon Chanthap; Ariey Frederic; Mercereau-Puijalon Odile; Menard Didier; Newton Paul N; Khanthavong Maniphone; Hongvanthong Bouasy; Khan Wasif A; Phyo Aung Pyae; Tan John C; Ferdig Michael T; Clark Taane G; Miotto Olivo; MacInnis Bronwyn; Kwiatkowski Dominic P; Ringwald Pascal</div><div class="citationInfo"><span class="NLM_cas:title">The Journal of infectious diseases</span>
+        (<span class="NLM_cas:date">2015</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">211</cas:volume>
+        (<span class="NLM_cas:issue">5</span>),
+    <span class="NLM_cas:pages">670-9</span>
+        ISSN:<span class="NLM_cas:issn"></span>.
+    </div><div class="casAbstract">BACKGROUND:  The emergence of artemisinin-resistant Plasmodium falciparum in Southeast Asia threatens malaria treatment efficacy.  Mutations in a kelch protein encoded on P. falciparum chromosome 13 (K13) have been associated with resistance in vitro and in field samples from Cambodia.  METHODS:  P. falciparum infections from artesunate efficacy trials in Bangladesh, Cambodia, Laos, Myanmar, and Vietnam were genotyped at 33 716 genome-wide single-nucleotide polymorphisms (SNPs).  Linear mixed models were used to test associations between parasite genotypes and parasite clearance half-lives following artesunate treatment.  K13 mutations were tested for association with artemisinin resistance, and extended haplotypes on chromosome 13 were examined to determine whether mutations arose focally and spread or whether they emerged independently.  RESULTS:  The presence of nonreference K13 alleles was associated with prolonged parasite clearance half-life (P = 1.97 × 10(-12)).  Parasites with a mutation in any of the K13 kelch domains displayed longer parasite clearance half-lives than parasites with wild-type alleles.  Haplotype analysis revealed both population-specific emergence of mutations and independent emergence of the same mutation in different geographic areas.  CONCLUSIONS:  K13 appears to be a major determinant of artemisinin resistance throughout Southeast Asia.  While we found some evidence of spreading resistance, there was no evidence of resistance moving westward from Cambodia into Myanmar.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=LOZGTtr2ZcS-NjMj0FtruZQHPYJuLg8TfW6udTcc2ea1Axw8-fIEDbntkvexoksv"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A280%3ADC%252BC2M%252FntFGgsg%253D%253D&amp;md5=f951db8da7bc72877f04d63184e295b2</span></div></div></div></div></li><li id="ref4"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref4');return false;" class="refNumLink">4. </a></strong><div class="NLM_citation" id="cit4"><span class="hlFld-ContribAuthor ">Wells<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. N.</span>; <span class="hlFld-ContribAuthor ">Hooft van Huijsduijnen<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">Van Voorhis<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>W. C.</span><span class="NLM_article-title">Malaria medicines: a glass half full?</span> <span class="citation_source-journal">Nat. Rev. Drug Discovery</span>  <span class="NLM_year">2015</span>,  <span class="NLM_volume">14</span>,  <span class="NLM_fpage">424</span>– <span class="NLM_lpage">442</span>, <span class="refDoi">DOI: 10.1038/nrd4573</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref4/cit4&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1038%2Fnrd4573" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref4/cit4&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=26000721" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref4/cit4&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC2MXhtFemsbvM" title="">CAS</a></a>]<div class="casRecord" id="cas_cit4R"><div class="casContent"><span class="casTitleNuber">4. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Malaria medicines: a glass half full?</cas:atitle></div><div class="casAuthors">Wells, Timothy N. C.; Hooft van Huijsduijnen, Rob; Van Voorhis, Wesley C.</div><div class="citationInfo"><span class="NLM_cas:title">Nature Reviews Drug Discovery</span>
+        (<span class="NLM_cas:date">2015</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">14</cas:volume>
+        (<span class="NLM_cas:issue">6</span>),
+    <span class="NLM_cas:pages">424-442</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">NRDDAG</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1474-1776</span>.
+    
+            (<span class="NLM_cas:orgname">Nature Publishing Group</span>)
+        </div><div class="casAbstract">A review.  Despite substantial scientific progress over the past two decades, malaria remains a worldwide burden that causes hundreds of thousands of deaths every year.  New, affordable and safe drugs are required to overcome increasing resistance against artemisinin-based treatments, treat vulnerable populations, interrupt the parasite life cycle by blocking transmission to the vectors, prevent infection and target malaria species that transiently remain dormant in the liver.  In this Review, we discuss how the antimalarial drug discovery pipeline has changed over the past 10 years, grouped by the various target compd. or product profiles, to assess progress and gaps, and to recommend priorities.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGqAJNZa5gyvg7Vg90H21EOLACvtfcHk0ljIx-bZieDR_A"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC2MXhtFemsbvM&amp;md5=43f35590f86c240a4150b5cb4f5670ad</span></div></div></div></div></li><li id="ref5"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref5');return false;" class="refNumLink">5. </a></strong><div class="NLM_citation" id="cit5"><span class="hlFld-ContribAuthor ">Baragana<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Hallyburton<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>I.</span>; <span class="hlFld-ContribAuthor ">Lee<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. C. S.</span>; <span class="hlFld-ContribAuthor ">Norcross<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. R.</span>; <span class="hlFld-ContribAuthor ">Grimaldi<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">Otto<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. D.</span>; <span class="hlFld-ContribAuthor ">Proto<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>W. R.</span>; <span class="hlFld-ContribAuthor ">Blagborough<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. M.</span>; <span class="hlFld-ContribAuthor ">Meister<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Wirjanata<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>G.</span>; <span class="hlFld-ContribAuthor ">Ruecker<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Upton<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>L. M.</span>; <span class="hlFld-ContribAuthor ">Abraham<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. S.</span>; <span class="hlFld-ContribAuthor ">Almeida<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. J.</span>; <span class="hlFld-ContribAuthor ">Pradhan<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Porzelle<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Martinez<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. S.</span>; <span class="hlFld-ContribAuthor ">Bolscher<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. M.</span>; <span class="hlFld-ContribAuthor ">Woodland<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Norval<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Zuccotto<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span>; <span class="hlFld-ContribAuthor ">Thomas<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Simeons<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F.</span>; <span class="hlFld-ContribAuthor ">Stojanovski<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>L.</span>; <span class="hlFld-ContribAuthor ">Osuna-Cabello<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Brock<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. M.</span>; <span class="hlFld-ContribAuthor ">Churcher<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. S.</span>; <span class="hlFld-ContribAuthor ">Sala<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. A.</span>; <span class="hlFld-ContribAuthor ">Zakutansky<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. E.</span>; <span class="hlFld-ContribAuthor ">Jimenez-Diaz<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. B.</span>; <span class="hlFld-ContribAuthor ">Sanz<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>L. M.</span>; <span class="hlFld-ContribAuthor ">Riley<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Basak<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">Campbell<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Avery<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>V. M.</span>; <span class="hlFld-ContribAuthor ">Sauerwein<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. W.</span>; <span class="hlFld-ContribAuthor ">Dechering<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. J.</span>; <span class="hlFld-ContribAuthor ">Noviyanti<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">Campo<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Frearson<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. A.</span>; <span class="hlFld-ContribAuthor ">Angulo-Barturen<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>I.</span>; <span class="hlFld-ContribAuthor ">Ferrer-Bazaga<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Gamo<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>F. J.</span>; <span class="hlFld-ContribAuthor ">Wyatt<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. G.</span>; <span class="hlFld-ContribAuthor ">Leroy<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Siegl<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Delves<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. J.</span>; <span class="hlFld-ContribAuthor ">Kyle<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. E.</span>; <span class="hlFld-ContribAuthor ">Wittlin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Marfurt<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Price<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. N.</span>; <span class="hlFld-ContribAuthor ">Sinden<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. E.</span>; <span class="hlFld-ContribAuthor ">Winzeler<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. A.</span>; <span class="hlFld-ContribAuthor ">Charman<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. A.</span>; <span class="hlFld-ContribAuthor ">Bebrevska<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>L.</span>; <span class="hlFld-ContribAuthor ">Gray<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. W.</span>; <span class="hlFld-ContribAuthor ">Campbell<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Fairlamb<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. H.</span>; <span class="hlFld-ContribAuthor ">Willis<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. A.</span>; <span class="hlFld-ContribAuthor ">Rayner<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. C.</span>; <span class="hlFld-ContribAuthor ">Fidock<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. A.</span>; <span class="hlFld-ContribAuthor ">Read<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. D.</span>; <span class="hlFld-ContribAuthor ">Gilbert<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>I. H.</span><span class="NLM_article-title">A novel multiple-stage antimalarial agent that inhibits protein synthesis</span> <span class="citation_source-journal">Nature</span>  <span class="NLM_year">2015</span>,  <span class="NLM_volume">522</span>,  <span class="NLM_fpage">315</span>– <span class="NLM_lpage">320</span>, <span class="refDoi">DOI: 10.1038/nature14451</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref5/cit5&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1038%2Fnature14451" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref5/cit5&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=26085270" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref5/cit5&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC2MXhtFeiurzE" title="">CAS</a></a>]<div class="casRecord" id="cas_cit5R"><div class="casContent"><span class="casTitleNuber">5. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">A novel multiple-stage antimalarial agent that inhibits protein synthesis</cas:atitle></div><div class="casAuthors">Baragana, Beatriz; Hallyburton, Irene; Lee, Marcus C. S.; Norcross, Neil R.; Grimaldi, Raffaella; Otto, Thomas D.; Proto, William R.; Blagborough, Andrew M.; Meister, Stephan; Wirjanata, Grennady; Ruecker, Andrea; Upton, Leanna M.; Abraham, Tara S.; Almeida, Mariana J.; Pradhan, Anupam; Porzelle, Achim; Martinez, Maria Santos; Bolscher, Judith M.; Woodland, Andrew; Norval, Suzanne; Zuccotto, Fabio; Thomas, John; Simeons, Frederick; Stojanovski, Laste; Osuna-Cabello, Maria; Brock, Paddy M.; Churcher, Tom S.; Sala, Katarzyna A.; Zakutansky, Sara E.; Jimenez-Diaz, Maria Belen; Sanz, Laura Maria; Riley, Jennifer; Basak, Rajshekhar; Campbell, Michael; Avery, Vicky M.; Sauerwein, Robert W.; Dechering, Koen J.; Noviyanti, Rintis; Campo, Brice; Frearson, Julie A.; Angulo-Barturen, Inigo; Ferrer-Bazaga, Santiago; Gamo, Francisco Javier; Wyatt, Paul G.; Leroy, Didier; Siegl, Peter; Delves, Michael J.; Kyle, Dennis E.; Wittlin, Sergio; Marfurt, Jutta; Price, Ric N.; Sinden, Robert E.; Winzeler, Elizabeth A.; Charman, Susan A.; Bebrevska, Lidiya; Gray, David W.; Campbell, Simon; Fairlamb, Alan H.; Willis, Paul A.; Rayner, Julian C.; Fidock, David A.; Read, Kevin D.; Gilbert, Ian H.</div><div class="citationInfo"><span class="NLM_cas:title">Nature (London, United Kingdom)</span>
+        (<span class="NLM_cas:date">2015</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">522</cas:volume>
+        (<span class="NLM_cas:issue">7556</span>),
+    <span class="NLM_cas:pages">315-320</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">NATUAS</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">0028-0836</span>.
+    
+            (<span class="NLM_cas:orgname">Nature Publishing Group</span>)
+        </div><div class="casAbstract">There is an urgent need for new drugs to treat malaria, with broad therapeutic potential and novel modes of action, to widen the scope of treatment and to overcome emerging drug resistance.  Here we describe the discovery of DDD107498, a compd. with a potent and novel spectrum of antimalarial activity against multiple life-cycle stages of the Plasmodium parasite, with good pharmacokinetic properties and an acceptable safety profile.  DDD107498 demonstrates potential to address a variety of clin. needs, including single-dose treatment, transmission blocking and chemoprotection.  DDD107498 was developed from a screening program against blood-stage malaria parasites; its mol. target has been identified as translation elongation factor 2 (eEF2), which is responsible for the GTP-dependent translocation of the ribosome along mRNA, and is essential for protein synthesis.  This discovery of eEF2 as a viable antimalarial drug target opens up new possibilities for drug discovery.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGqhDYwtxN92qrVg90H21EOLACvtfcHk0liMHUJLMUgIqg"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC2MXhtFeiurzE&amp;md5=bd5f1dd3c4389aa8a6f193df0aa068a1</span></div></div></div></div></li><li id="ref6"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref6');return false;" class="refNumLink">6. </a></strong><div class="NLM_citation" id="cit6"><span class="hlFld-ContribAuthor ">Brenk<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">Schipani<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">James<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Krasowski<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Gilbert<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>I. H.</span>; <span class="hlFld-ContribAuthor ">Frearson<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Wyatt<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. G.</span><span class="NLM_article-title">Lessons learnt from assembling screening libraries for drug discovery for neglected diseases</span> <span class="citation_source-journal">ChemMedChem</span>  <span class="NLM_year">2008</span>,  <span class="NLM_volume">3</span>,  <span class="NLM_fpage">435</span>– <span class="NLM_lpage">444</span>, <span class="refDoi">DOI: 10.1002/cmdc.200700139</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref6/cit6&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1002%2Fcmdc.200700139" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref6/cit6&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=18064617" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref6/cit6&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BD1cXlt1Krtb4%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit6R"><div class="casContent"><span class="casTitleNuber">6. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Lessons learned from assembling screening libraries for drug discovery for neglected diseases</cas:atitle></div><div class="casAuthors">Brenk, Ruth; Schipani, Alessandro; James, Daniel; Krasowski, Agata; Gilbert, Ian Hugh; Frearson, Julie; Wyatt, Paul Graham</div><div class="citationInfo"><span class="NLM_cas:title">ChemMedChem</span>
+        (<span class="NLM_cas:date">2008</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">3</cas:volume>
+        (<span class="NLM_cas:issue">3</span>),
+    <span class="NLM_cas:pages">435-444</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">CHEMGX</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1860-7179</span>.
+    
+            (<span class="NLM_cas:orgname">Wiley-VCH Verlag GmbH &amp; Co. KGaA</span>)
+        </div><div class="casAbstract">To enable the establishment of a drug discovery operation for neglected diseases, out of 2.3 million com. available compds. 222 552 compds. were selected for an in silico library, 57 438 for a diverse general screening library, and 1 697 compds. for a focused kinase set.  Compiling these libraries required a robust strategy for compd. selection.  Rules for unwanted groups were defined and selection criteria to enrich for lead-like compds. which facilitate straightforward structure-activity relationship exploration were established.  Further, a literature and patent review was undertaken to ext. key recognition elements of kinase inhibitors ("core fragments") to assemble a focused library for hit discovery for kinases.  Computational and exptl. characterization of the general screening library revealed that the selected compds. (1) span a broad range of lead-like space, (2) show a high degree of structural integrity and purity, and (3) demonstrate appropriate soly. for the purposes of biochem. screening.  The implications of this study for compd. selection, esp. in an academic environment with limited resources, are considered.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGqy_Ybsdg8QS7Vg90H21EOLACvtfcHk0liMHUJLMUgIqg"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BD1cXlt1Krtb4%253D&amp;md5=b804d0ac8766e954391798e24aa7fbff</span></div></div></div></div></li><li id="ref7"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref7');return false;" class="refNumLink">7. </a></strong><div class="NLM_citation" id="cit7"><span class="hlFld-ContribAuthor ">Burrows<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. N.</span>; <span class="hlFld-ContribAuthor ">Hooft van Huijsduijnen<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. H.</span>; <span class="hlFld-ContribAuthor ">Mohrle<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. J.</span>; <span class="hlFld-ContribAuthor ">Oeuvray<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C.</span>; <span class="hlFld-ContribAuthor ">Wells<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. N.</span><span class="NLM_article-title">Designing the next generation of medicines for malaria control and eradication</span> <span class="citation_source-journal">Malar. J.</span>  <span class="NLM_year">2013</span>,  <span class="NLM_volume">12</span>,  <span class="NLM_fpage">187</span>, <span class="refDoi">DOI: 10.1186/1475-2875-12-187</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref7/cit7&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1186%2F1475-2875-12-187" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref7/cit7&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=23742293" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref7/cit7&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A280%3ADC%252BC3sjgsVSisA%253D%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit7R"><div class="casContent"><span class="casTitleNuber">7. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Designing the next generation of medicines for malaria control and eradication</cas:atitle></div><div class="casAuthors">Burrows Jeremy N; van Huijsduijnen Rob Hooft; Mohrle Jorg J; Oeuvray Claude; Wells Timothy N C</div><div class="citationInfo"><span class="NLM_cas:title">Malaria journal</span>
+        (<span class="NLM_cas:date">2013</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">12</cas:volume>
+        (<span class="NLM_cas:issue"></span>),
+    <span class="NLM_cas:pages">187</span>
+        ISSN:<span class="NLM_cas:issn"></span>.
+    </div><div class="casAbstract">In the fight against malaria new medicines are an essential weapon.  For the parts of the world where the current gold standard artemisinin combination therapies are active, significant improvements can still be made: for example combination medicines which allow for single dose regimens, cheaper, safer and more effective medicines, or improved stability under field conditions.  For those parts of the world where the existing combinations show less than optimal activity, the priority is to have activity against emerging resistant strains, and other criteria take a secondary role.  For new medicines to be optimal in malaria control they must also be able to reduce transmission and prevent relapse of dormant forms: additional constraints on a combination medicine.  In the absence of a highly effective vaccine, new medicines are also needed to protect patient populations.  In this paper, an outline definition of the ideal and minimally acceptable characteristics of the types of clinical candidate molecule which are needed (target candidate profiles) is suggested.  In addition, the optimal and minimally acceptable characteristics of combination medicines are outlined (target product profiles).  MMV presents now a suggested framework for combining the new candidates to produce the new medicines.  Sustained investment over the next decade in discovery and development of new molecules is essential to enable the long-term delivery of the medicines needed to combat malaria.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=LOZGTtr2ZcSjy7sj0k3cHtFxYDaSSP8XfW6udTcc2eYAZzDMYSxKnrntkvexoksv"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A280%3ADC%252BC3sjgsVSisA%253D%253D&amp;md5=c4283af83b04bc217f40528dde196e23</span></div></div></div></div></li><li id="ref8"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref8');return false;" class="refNumLink">8. </a></strong><div class="NLM_citation" id="cit8a">(a) <span class="hlFld-ContribAuthor ">Leeson<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. D.</span>; <span class="hlFld-ContribAuthor ">Young<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. J.</span><span class="NLM_article-title">Molecular property design: does everyone get it?</span> <span class="citation_source-journal">ACS Med. Chem. Lett.</span>  <span class="NLM_year">2015</span>,  <span class="NLM_volume">6</span>,  <span class="NLM_fpage">722</span>– <span class="NLM_lpage">725</span>, <span class="refDoi">DOI: 10.1021/acsmedchemlett.5b00157</span> <div class="citationLinks">[<a href="/doi/10.1021/acsmedchemlett.5b00157" title="">ACS Full Text <img src="/templates/jsp/_style2/_achs/images/acs-ref.gif" alt="ACS Full Text" /></a>], [<a href="/servlet/linkout?suffix=ref8/cit8a&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC2MXptVGksr4%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit8aR"><div class="casContent"><span class="casTitleNuber">8a. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Molecular Property Design: Does Everyone Get It?</cas:atitle></div><div class="casAuthors">Leeson, Paul D.; Young, Robert J.</div><div class="citationInfo"><span class="NLM_cas:title">ACS Medicinal Chemistry Letters</span>
+        (<span class="NLM_cas:date">2015</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">6</cas:volume>
+        (<span class="NLM_cas:issue">7</span>),
+    <span class="NLM_cas:pages">722-725</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">AMCLCT</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1948-5875</span>.
+    
+            (<span class="NLM_cas:orgname">American Chemical Society</span>)
+        </div><div class="casAbstract">A review.  The principles of mol. property optimization in drug design have been understood for decades, yet much drug discovery activity today is conducted at the periphery of historical druglike property space.  Lead optimization trajectories aimed at reducing physicochem. risk, assisted by ligand efficiency metrics, could help to reduce clin. attrition rates.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGro_t8gIn79arVg90H21EOLACvtfcHk0lgNbZkAMgZZXw"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC2MXptVGksr4%253D&amp;md5=5a807a8d049ce8cf4adc186891a9234d</span></div></div></div><div class="NLM_citation" id="cit8b">(b) <span class="hlFld-ContribAuthor ">Hann<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. M.</span><span class="NLM_article-title">Molecular obesity, potency and other addictions in drug discovery</span> <span class="citation_source-journal">MedChemComm</span>  <span class="NLM_year">2011</span>,  <span class="NLM_volume">2</span>,  <span class="NLM_fpage">349</span>– <span class="NLM_lpage">355</span>, <span class="refDoi">DOI: 10.1039/c1md00017a</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref8/cit8b&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1039%2Fc1md00017a" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref8/cit8b&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC3MXls1Kht7g%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit8bR"><div class="casContent"><span class="casTitleNuber">8b. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Molecular obesity, potency and other addictions in drug discovery</cas:atitle></div><div class="casAuthors">Hann, Michael M.</div><div class="citationInfo"><span class="NLM_cas:title">MedChemComm</span>
+        (<span class="NLM_cas:date">2011</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">2</cas:volume>
+        (<span class="NLM_cas:issue">5</span>),
+    <span class="NLM_cas:pages">349-355</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">MCCEAY</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">2040-2503</span>.
+    
+            (<span class="NLM_cas:orgname">Royal Society of Chemistry</span>)
+        </div><div class="casAbstract">A review.  Despite the increase in global biol. and chem. knowledge the discovery of effective and safe new drugs seems to become harder rather than easier.  Some of this challenge is due to increasing demands for safety and novelty, but some of the risk involved in this should be controllable if we had more effectively learned from our failures.  This perspective reflects on some of the learnings of recent years in relation to the causes of attrition.  The term Mol. Obesity is introduced to describe our tendency to build potency into mols. by the inappropriate use of lipophilicity which leads to the premature demise of drug candidates.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGqSlF7TPy6fHLVg90H21EOLACvtfcHk0lgNbZkAMgZZXw"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC3MXls1Kht7g%253D&amp;md5=954870db4b1d9e846612c3bb256582f7</span></div></div></div></div></li><li id="ref9"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref9');return false;" class="refNumLink">9. </a></strong><div class="NLM_citation" id="cit9a">(a) <span class="hlFld-ContribAuthor ">Ritchie<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. J.</span>; <span class="hlFld-ContribAuthor ">Macdonald<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. J. F.</span><span class="NLM_article-title">The impact of aromatic ring count on compound developability - are too many aromatic rings a liability in drug design?</span> <span class="citation_source-journal">Drug Discovery Today</span>  <span class="NLM_year">2009</span>,  <span class="NLM_volume">14</span>,  <span class="NLM_fpage">1011</span>– <span class="NLM_lpage">1020</span>, <span class="refDoi">DOI: 10.1016/j.drudis.2009.07.014</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref9/cit9a&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1016%2Fj.drudis.2009.07.014" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref9/cit9a&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=19729075" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref9/cit9a&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BD1MXhtlCgt7nP" title="">CAS</a></a>]<div class="casRecord" id="cas_cit9aR"><div class="casContent"><span class="casTitleNuber">9a. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">The impact of aromatic ring count on compound developability: Are too many aromatic rings a liability in drug design?</cas:atitle></div><div class="casAuthors">Ritchie, Timothy J.; MacDonald, Simon J. F.</div><div class="citationInfo"><span class="NLM_cas:title">Drug Discovery Today</span>
+        (<span class="NLM_cas:date">2009</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">14</cas:volume>
+        (<span class="NLM_cas:issue">21/22</span>),
+    <span class="NLM_cas:pages">1011-1020</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">DDTOFS</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1359-6446</span>.
+    
+            (<span class="NLM_cas:orgname">Elsevier B.V.</span>)
+        </div><div class="casAbstract">A review.  The impact of arom. ring count (the no. of arom. and heteroarom. rings) in mols. has been analyzed against various developability parameters, aq. soly., lipophilicity, serum albumin binding, CyP450 inhibition and hERG inhibition.  On the basis of this anal., it was concluded that the fewer arom. rings contained in an oral drug candidate, the more developable that candidate is probably to be; in addn., more than three arom. rings in a mol. correlates with poorer compd. developability and, thus, an increased risk of attrition in development.  Data are also presented that demonstrate that even within a defined lipophilicity range, increased arom. ring count leads to decreased aq. soly.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGr2hOeD6TNGUbVg90H21EOLACvtfcHk0lgNbZkAMgZZXw"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BD1MXhtlCgt7nP&amp;md5=48454c9809e8225b4336ea76aad3f3ba</span></div></div></div><div class="NLM_citation" id="cit9b">(b) <span class="hlFld-ContribAuthor ">Ritchie<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. J.</span>; <span class="hlFld-ContribAuthor ">MacDonald<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. J. F.</span>; <span class="hlFld-ContribAuthor ">Young<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. J.</span>; <span class="hlFld-ContribAuthor ">Pickett<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. D.</span><span class="NLM_article-title">The impact of aromatic ring count on compound developability: further insights by examiing carbo- and hetero-aromatic and -aliphatic ring types</span> <span class="citation_source-journal">Drug Discovery Today</span>  <span class="NLM_year">2011</span>,  <span class="NLM_volume">16</span>,  <span class="NLM_fpage">164</span>– <span class="NLM_lpage">171</span>, <span class="refDoi">DOI: 10.1016/j.drudis.2010.11.014</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref9/cit9b&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1016%2Fj.drudis.2010.11.014" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref9/cit9b&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=21129497" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref9/cit9b&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC3MXhvVyqsr0%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit9bR"><div class="casContent"><span class="casTitleNuber">9b. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">The impact of aromatic ring count on compound developability: further insights by examining carbo- and hetero-aromatic and -aliphatic ring types</cas:atitle></div><div class="casAuthors">Ritchie, Timothy J.; MacDonald, Simon J. F.; Young, Robert J.; Pickett, Stephen D.</div><div class="citationInfo"><span class="NLM_cas:title">Drug Discovery Today</span>
+        (<span class="NLM_cas:date">2011</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">16</cas:volume>
+        (<span class="NLM_cas:issue">3/4</span>),
+    <span class="NLM_cas:pages">164-171</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">DDTOFS</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1359-6446</span>.
+    
+            (<span class="NLM_cas:orgname">Elsevier B.V.</span>)
+        </div><div class="casAbstract">A review.  The impact of carboarom., heteroarom., carboaliph. and heteroaliph. ring counts and fused arom. ring count on several developability measures (soly., lipophilicity, protein binding, P 450 inhibition and hERG binding) is the topic for this review article.  Recent results indicate that increasing ring counts have detrimental effects on developability in the order carboaroms. » heteroaroms. &gt; carboaliphatics &gt; heteroaliphatics, with heteroaliphatics exerting a beneficial effect in many cases.  Increasing arom. ring count exerts effects on several developability parameters that are lipophilicity- and size-independent, and fused arom. systems have a beneficial effect relative to their nonfused counterparts.  Increasing arom. ring count has a detrimental effect on human bioavailability parameters, and heteroarom. ring count (but not other ring counts) has increased over time in marketed oral drugs.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGqJYPC7hkoyv7Vg90H21EOLACvtfcHk0lgNbZkAMgZZXw"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC3MXhvVyqsr0%253D&amp;md5=8e2d0e4e499d2f07d66ca2f385defb2d</span></div></div></div></div></li><li id="ref10"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref10');return false;" class="refNumLink">10. </a></strong><div class="NLM_citation" id="cit10"><span class="hlFld-ContribAuthor ">El Ashry<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. S. H.</span>; <span class="hlFld-ContribAuthor ">Ramadan<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. S.</span>; <span class="hlFld-ContribAuthor ">Abdel Hamid<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>H.</span>; <span class="hlFld-ContribAuthor ">Hagar<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span><span class="NLM_article-title">Microwave-assisted synthesis of quinoline derivatives from isatin</span> <span class="citation_source-journal">Synth. Commun.</span>  <span class="NLM_year">2005</span>,  <span class="NLM_volume">35</span>,  <span class="NLM_fpage">2243</span>– <span class="NLM_lpage">2250</span>, <span class="refDoi">DOI: 10.1080/00397910500184719</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref10/cit10&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1080%2F00397910500184719" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref10/cit10&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BD2MXpvVShtb0%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit10R"><div class="casContent"><span class="casTitleNuber">10. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Microwave-assisted synthesis of quinoline derivatives from isatin</cas:atitle></div><div class="casAuthors">El Ashry, El Sayed; Ramadan, El Sayed; Abdel Hamid, Hamida; Hagar, Mohamed</div><div class="citationInfo"><span class="NLM_cas:title">Synthetic Communications</span>
+        (<span class="NLM_cas:date">2005</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">35</cas:volume>
+        (<span class="NLM_cas:issue">17</span>),
+    <span class="NLM_cas:pages">2243-2250</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">SYNCAV</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">0039-7911</span>.
+    
+            (<span class="NLM_cas:orgname">Taylor &amp; Francis, Inc.</span>)
+        </div><div class="casAbstract">Microwave irradn. (MWI) was used for a rapid and efficient synthesis of quinoline-4-carboxylic acids and 1,2,3,4-tetrahydroacridine-9-carboxylic acid from the reaction of isatins with acyclic and cyclic ketones in basic medium. 2-Hydroxyquinoline-4-carboxylic acid was also obtained by irradiating a mixt. of isatin and malonic acid in AcOH.  The esters of 2-phenyl- and 2-hydroxy-quinoline-4-carboxylic acids their resp. hydrazides were also prepd. under MWI.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGrz9TYNTS2A37Vg90H21EOLACvtfcHk0lgFuwJHkltMsQ"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BD2MXpvVShtb0%253D&amp;md5=191be26d9a70311bbeaa8d54e5ee6333</span></div></div></div></div></li><li id="ref11"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref11');return false;" class="refNumLink">11. </a></strong><div class="NLM_citation" id="cit11"><span class="hlFld-ContribAuthor ">Leeson<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. D.</span>; <span class="hlFld-ContribAuthor ">Springthorpe<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span><span class="NLM_article-title">The influence of drug-like concepts on decision-making in medicinal chemistry</span> <span class="citation_source-journal">Nat. Rev. Drug Discovery</span>  <span class="NLM_year">2007</span>,  <span class="NLM_volume">6</span>,  <span class="NLM_fpage">881</span>– <span class="NLM_lpage">890</span>, <span class="refDoi">DOI: 10.1038/nrd2445</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref11/cit11&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1038%2Fnrd2445" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref11/cit11&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=17971784" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref11/cit11&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BD2sXht1els7rL" title="">CAS</a></a>]<div class="casRecord" id="cas_cit11R"><div class="casContent"><span class="casTitleNuber">11. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">The influence of drug-like concepts on decision-making in medicinal chemistry</cas:atitle></div><div class="casAuthors">Leeson, Paul D.; Springthorpe, Brian</div><div class="citationInfo"><span class="NLM_cas:title">Nature Reviews Drug Discovery</span>
+        (<span class="NLM_cas:date">2007</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">6</cas:volume>
+        (<span class="NLM_cas:issue">11</span>),
+    <span class="NLM_cas:pages">881-890</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">NRDDAG</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1474-1776</span>.
+    
+            (<span class="NLM_cas:orgname">Nature Publishing Group</span>)
+        </div><div class="casAbstract">A review.  Despite the wide acceptance of drug-like principles such as the 'rule of five', this anal. of mols. currently being synthesized in leading pharmaceutical companies reveals that their phys. properties differ significantly from those of recently discovered oral drugs.  The marked increase in lipophilicity in particular could increase the likelihood of attrition in drug development.  The application of guidelines linked to the concept of drug-likeness, such as the 'rule of five', has gained wide acceptance as an approach to reduce attrition in drug discovery and development.  However, despite this acceptance, anal. of recent trends reveals that the phys. properties of mols. that are currently being synthesized in leading drug discovery companies differ significantly from those of recently discovered oral drugs and compds. in clin. development.  The consequences of the marked increase in lipophilicity - the most important drug-like phys. property - include a greater likelihood of lack of selectivity and attrition in drug development.  Tackling the threat of compd.-related toxicol. attrition needs to move to the mainstream of medicinal chem. decision-making.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGoTUeonLD6iebVg90H21EOLACvtfcHk0lgFuwJHkltMsQ"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BD2sXht1els7rL&amp;md5=5665a9e2dc266a1ee096e20625757ef7</span></div></div></div></div></li><li id="ref12"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref12');return false;" class="refNumLink">12. </a></strong><div class="NLM_citation" id="cit12"><span class="hlFld-ContribAuthor ">Dulla<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Wan<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Franzblau<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. G.</span>; <span class="hlFld-ContribAuthor ">Kapavarapu<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">Reiser<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>O.</span>; <span class="hlFld-ContribAuthor ">Iqbal<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Pal<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span><span class="NLM_article-title">Construction and functionalization of fused pyridine ring leading to novel compounds as potential antitubercular agents</span> <span class="citation_source-journal">Bioorg. Med. Chem. Lett.</span>  <span class="NLM_year">2012</span>,  <span class="NLM_volume">22</span>,  <span class="NLM_fpage">4629</span>– <span class="NLM_lpage">4635</span>, <span class="refDoi">DOI: 10.1016/j.bmcl.2012.05.096</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref12/cit12&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1016%2Fj.bmcl.2012.05.096" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref12/cit12&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=22726932" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref12/cit12&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC38XovFWktL4%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit12R"><div class="casContent"><span class="casTitleNuber">12. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Construction and functionalization of fused pyridine ring leading to novel compounds as potential antitubercular agents</cas:atitle></div><div class="casAuthors">Dulla, Balakrishna; Wan, Baojie; Franzblau, Scott G.; Kapavarapu, Ravikumar; Reiser, Oliver; Iqbal, Javed; Pal, Manojit</div><div class="citationInfo"><span class="NLM_cas:title">Bioorganic &amp; Medicinal Chemistry Letters</span>
+        (<span class="NLM_cas:date">2012</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">22</cas:volume>
+        (<span class="NLM_cas:issue">14</span>),
+    <span class="NLM_cas:pages">4629-4635</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">BMCLE8</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">0960-894X</span>.
+    
+            (<span class="NLM_cas:orgname">Elsevier B.V.</span>)
+        </div><div class="casAbstract">A series of fused and functionalized pyridine derivs. was designed, synthesized and tested for potential antitubercular properties.  All these novel compds. were prepd. by using multistep methods involving the construction of the pyridine ring as a key synthetic step.  Some of these compds. were found to be interesting when tested for their antitubercular properties in vitro and one of them, I, emerged as an attractive and potential antitubercular agent.  In addn., mol. docking to the shikimate dehydrogenase protein of Mycobacterium tuberculosis was carried out for several of the target mols.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGpg3ctJjAXoILVg90H21EOLACvtfcHk0lgFuwJHkltMsQ"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC38XovFWktL4%253D&amp;md5=2f86e4b13258be4966f5da4a22f25e56</span></div></div></div></div></li><li id="ref13"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref13');return false;" class="refNumLink">13. </a></strong><div class="NLM_citation" id="cit13"><span class="hlFld-ContribAuthor ">Böhm<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>H.-J.</span>; <span class="hlFld-ContribAuthor ">Banner<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Bendels<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Kansy<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Kuhn<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Müller<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K.</span>; <span class="hlFld-ContribAuthor ">Obst-Sander<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>U.</span>; <span class="hlFld-ContribAuthor ">Stahl<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span><span class="NLM_article-title">Fluorine in medicinal chemistry</span> <span class="citation_source-journal">ChemBioChem</span>  <span class="NLM_year">2004</span>,  <span class="NLM_volume">5</span>,  <span class="NLM_fpage">637</span>– <span class="NLM_lpage">643</span>, <span class="refDoi">DOI: 10.1002/cbic.200301023</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref13/cit13&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1002%2Fcbic.200301023" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref13/cit13&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=15122635" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref13/cit13&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A280%3ADC%252BD2c3it1egug%253D%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit13R"><div class="casContent"><span class="casTitleNuber">13. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Fluorine in medicinal chemistry</cas:atitle></div><div class="casAuthors">Bohm Hans-Joachim; Banner David; Bendels Stefanie; Kansy Manfred; Kuhn Bernd; Muller Klaus; Obst-Sander Ulrike; Stahl Martin</div><div class="citationInfo"><span class="NLM_cas:title">Chembiochem : a European journal of chemical biology</span>
+        (<span class="NLM_cas:date">2004</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">5</cas:volume>
+        (<span class="NLM_cas:issue">5</span>),
+    <span class="NLM_cas:pages">637-43</span>
+        ISSN:<span class="NLM_cas:issn">1439-4227</span>.
+    </div><div class="casAbstract">Fluorinated compounds are synthesized in pharmaceutical research on a routine basis and many marketed compounds contain fluorine.  The present review summarizes some of the most frequently employed strategies for using fluorine substituents in medicinal chemistry.  Quite often, fluorine is introduced to improve the metabolic stability by blocking metabolically labile sites.  However, fluorine can also be used to modulate the physicochemical properties, such as lipophilicity or basicity.  It may exert a substantial effect on the conformation of a molecule.  Increasingly, fluorine is used to enhance the binding affinity to the target protein.  Recent 3D-structure determinations of protein complexes with bound fluorinated ligands have led to an improved understanding of the nonbonding protein-ligand interactions that involve fluorine.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=LOZGTtr2ZcQ4zDG_wo1YGtts4TFFB11gfW6udTcc2eY-GIqnviFblrntkvexoksv"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A280%3ADC%252BD2c3it1egug%253D%253D&amp;md5=fa5ca2cfc278b83c80d5c96b18dfe312</span></div></div></div></div></li><li id="ref14"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref14');return false;" class="refNumLink">14. </a></strong><div class="NLM_citation" id="cit14a">(a) <span class="hlFld-ContribAuthor ">Meister<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Plouffe<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. M.</span>; <span class="hlFld-ContribAuthor ">Kuhen<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K. L.</span>; <span class="hlFld-ContribAuthor ">Bonamy<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>G. M. C.</span>; <span class="hlFld-ContribAuthor ">Wu<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T.</span>; <span class="hlFld-ContribAuthor ">Barnes<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. W.</span>; <span class="hlFld-ContribAuthor ">Bopp<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S. E.</span>; <span class="hlFld-ContribAuthor ">Borboa<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R.</span>; <span class="hlFld-ContribAuthor ">Bright<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A. T.</span>; <span class="hlFld-ContribAuthor ">Che<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Cohen<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Dharia<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N. V.</span>; <span class="hlFld-ContribAuthor ">Gagaring<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>K.</span>; <span class="hlFld-ContribAuthor ">Gettayacamin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Gordon<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Groessl<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T.</span>; <span class="hlFld-ContribAuthor ">Kato<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>N.</span>; <span class="hlFld-ContribAuthor ">Lee<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M. C. S.</span>; <span class="hlFld-ContribAuthor ">McNamara<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C. W.</span>; <span class="hlFld-ContribAuthor ">Fidock<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D. A.</span>; <span class="hlFld-ContribAuthor ">Nagle<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Nam<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T.-g.</span>; <span class="hlFld-ContribAuthor ">Richmond<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>W.</span>; <span class="hlFld-ContribAuthor ">Roland<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Rottmann<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Zhou<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>B.</span>; <span class="hlFld-ContribAuthor ">Froissard<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P.</span>; <span class="hlFld-ContribAuthor ">Glynne<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. J.</span>; <span class="hlFld-ContribAuthor ">Mazier<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Sattabongkot<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J.</span>; <span class="hlFld-ContribAuthor ">Schultz<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>P. G.</span>; <span class="hlFld-ContribAuthor ">Tuntland<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T.</span>; <span class="hlFld-ContribAuthor ">Walker<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>J. R.</span>; <span class="hlFld-ContribAuthor ">Zhou<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>Y.</span>; <span class="hlFld-ContribAuthor ">Chatterjee<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>A.</span>; <span class="hlFld-ContribAuthor ">Diagana<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>T. T.</span>; <span class="hlFld-ContribAuthor ">Winzeler<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. A.</span><span class="NLM_article-title">Imaging of Plasmodium liver stages to drive next-generation antimalarial drug discovery</span> <span class="citation_source-journal">Science</span>  <span class="NLM_year">2011</span>,  <span class="NLM_volume">334</span>,  <span class="NLM_fpage">1372</span>– <span class="NLM_lpage">1377</span>, <span class="refDoi">DOI: 10.1126/science.1211936</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref14/cit14a&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1126%2Fscience.1211936" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref14/cit14a&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=22096101" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref14/cit14a&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC3MXhsFOjt7vN" title="">CAS</a></a>]<div class="casRecord" id="cas_cit14aR"><div class="casContent"><span class="casTitleNuber">14a. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Imaging of Plasmodium Liver Stages to Drive Next-Generation Antimalarial Drug Discovery</cas:atitle></div><div class="casAuthors">Meister, Stephan; Plouffe, David M.; Kuhen, Kelli L.; Bonamy, Ghislain M. C.; Wu, Tao; Barnes, S. Whitney; Bopp, Selina E.; Borboa, Rachel; Bright, A. Taylor; Che, Jianwei; Cohen, Steve; Dharia, Neekesh V.; Gagaring, Kerstin; Gettayacamin, Montip; Gordon, Perry; Groessl, Todd; Kato, Nobutaka; Lee, Marcus C. S.; McNamara, Case W.; Fidock, David A.; Nagle, Advait; Nam, Tae-gyu; Richmond, Wendy; Roland, Jason; Rottmann, Matthias; Zhou, Bin; Froissard, Patrick; Glynne, Richard J.; Mazier, Dominique; Sattabongkot, Jetsumon; Schultz, Peter G.; Tuntland, Tove; Walker, John R.; Zhou, Yingyao; Chatterjee, Arnab; Diagana, Thierry T.; Winzeler, Elizabeth A.</div><div class="citationInfo"><span class="NLM_cas:title">Science (Washington, DC, United States)</span>
+        (<span class="NLM_cas:date">2011</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">334</cas:volume>
+        (<span class="NLM_cas:issue">6061</span>),
+    <span class="NLM_cas:pages">1372-1377</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">SCIEAS</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">0036-8075</span>.
+    
+            (<span class="NLM_cas:orgname">American Association for the Advancement of Science</span>)
+        </div><div class="casAbstract">Most malaria drug development focuses on parasite stages detected in red blood cells, even though, to achieve eradication, next-generation drugs active against both erythrocytic and exo-erythrocytic forms would be preferable.  We applied a multifactorial approach to a set of &gt;4000 com. available compds. with previously demonstrated blood-stage activity (median inhibitory concn. &lt; 1 micromolar) and identified chem. scaffolds with potent activity against both forms.  From this screen, we identified an imidazolopiperazine scaffold series that was highly enriched among compds. active against Plasmodium liver stages.  The orally bioavailable lead imidazolopiperazine confers complete causal prophylactic protection (15 mg/kg) in rodent models of malaria and shows potent in vivo blood-stage therapeutic activity.  The open-source chem. tools resulting from our effort provide starting points for future drug discovery programs, as well as opportunities for researchers to investigate the biol. of exo-erythrocytic forms.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGpyO41naZtcdrVg90H21EOLACvtfcHk0li7wSeVq4gSTw"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC3MXhsFOjt7vN&amp;md5=45b2993be36e36eabe1d9280c86c3db2</span></div></div></div><div class="NLM_citation" id="cit14b">(b) <span class="hlFld-ContribAuthor ">Delves<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>M.</span>; <span class="hlFld-ContribAuthor ">Plouffe<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span>; <span class="hlFld-ContribAuthor ">Scheurer<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>C.</span>; <span class="hlFld-ContribAuthor ">Meister<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Wittlin<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Winzeler<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>E. A.</span>; <span class="hlFld-ContribAuthor ">Sinden<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>R. E.</span>; <span class="hlFld-ContribAuthor ">Leroy<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>D.</span><span class="NLM_article-title">The activities of current antimalarial drugs on the life cycle stages of Plasmodium: a comparative study with human and rodent parasites</span> <span class="citation_source-journal">PLoS Med.</span>  <span class="NLM_year">2012</span>,  <span class="NLM_volume">9</span>,  <span class="NLM_fpage">e1001169</span>, <span class="refDoi">DOI: 10.1371/journal.pmed.1001169</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref14/cit14b&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1371%2Fjournal.pmed.1001169" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref14/cit14b&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=22363211" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref14/cit14b&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A280%3ADC%252BC383mtVeisw%253D%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit14bR"><div class="casContent"><span class="casTitleNuber">14b. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">The activities of current antimalarial drugs on the life cycle stages of Plasmodium: a comparative study with human and rodent parasites</cas:atitle></div><div class="casAuthors">Delves Michael; Plouffe David; Scheurer Christian; Meister Stephan; Wittlin Sergio; Winzeler Elizabeth A; Sinden Robert E; Leroy Didier</div><div class="citationInfo"><span class="NLM_cas:title">PLoS medicine</span>
+        (<span class="NLM_cas:date">2012</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">9</cas:volume>
+        (<span class="NLM_cas:issue">2</span>),
+    <span class="NLM_cas:pages">e1001169</span>
+        ISSN:<span class="NLM_cas:issn"></span>.
+    </div><div class="casAbstract">BACKGROUND:  Malaria remains a disease of devastating global impact, killing more than 800,000 people every year-the vast majority being children under the age of 5.  While effective therapies are available, if malaria is to be eradicated a broader range of small molecule therapeutics that are able to target the liver and the transmissible sexual stages are required.  These new medicines are needed both to meet the challenge of malaria eradication and to circumvent resistance.  METHODS AND FINDINGS:  Little is known about the wider stage-specific activities of current antimalarials that were primarily designed to alleviate symptoms of malaria in the blood stage.  To overcome this critical gap, we developed assays to measure activity of antimalarials against all life stages of malaria parasites, using a diverse set of human and nonhuman parasite species, including male gamete production (exflagellation) in Plasmodium falciparum, ookinete development in P. berghei, oocyst development in P. berghei and P. falciparum, and the liver stage of P. yoelii.  We then compared 50 current and experimental antimalarials in these assays.  We show that endoperoxides such as OZ439, a stable synthetic molecule currently in clinical phase IIa trials, are strong inhibitors of gametocyte maturation/gamete formation and impact sporogony; lumefantrine impairs development in the vector; and NPC-1161B, a new 8-aminoquinoline, inhibits sporogony.  CONCLUSIONS:  These data enable objective comparisons of the strengths and weaknesses of each chemical class at targeting each stage of the lifecycle.  Noting that the activities of many compounds lie within achievable blood concentrations, these results offer an invaluable guide to decisions regarding which drugs to combine in the next-generation of antimalarial drugs.  This study might reveal the potential of life-cycle-wide analyses of drugs for other pathogens with complex life cycles.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=LOZGTtr2ZcSdvnJIZ7RZgQyMywPm6HgQfW6udTcc2eZg2XMzesykHLntkvexoksv"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A280%3ADC%252BC383mtVeisw%253D%253D&amp;md5=f2f23a53d58ad1ba583f575973b928b6</span></div></div></div></div></li><li id="ref15"><div class="reference"><strong class="refLabel"><a href="JavaScript:void(0);" onclick="showRef(event, 'ref15');return false;" class="refNumLink">15. </a></strong><div class="NLM_citation" id="cit15"><span class="hlFld-ContribAuthor ">Duffy<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>S.</span>; <span class="hlFld-ContribAuthor ">Avery<span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve">, </x></span>V. M.</span><span class="NLM_article-title">Identification of inhibitors of Plasmodium falciparum gametocyte development</span> <span class="citation_source-journal">Malar. J.</span>  <span class="NLM_year">2013</span>,  <span class="NLM_volume">12</span>,  <span class="NLM_fpage">408</span>, <span class="refDoi">DOI: 10.1186/1475-2875-12-408</span> <div class="citationLinks">[<a href="/servlet/linkout?suffix=ref15/cit15&amp;dbid=16&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=10.1186%2F1475-2875-12-408" title="">CrossRef</a>], [<a href="/servlet/linkout?suffix=ref15/cit15&amp;dbid=8&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=24206914" title="">PubMed</a>], [<a href="/servlet/linkout?suffix=ref15/cit15&amp;dbid=32&amp;doi=10.1021%2Facs.jmedchem.6b00723&amp;key=1%3ACAS%3A528%3ADC%252BC2cXmvFehs7k%253D" title="">CAS</a></a>]<div class="casRecord" id="cas_cit15R"><div class="casContent"><span class="casTitleNuber">15. </span><div class="casTitle"><cas:atitle xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">Identification of inhibitors of Plasmodium falciparum gametocyte development</cas:atitle></div><div class="casAuthors">Duffy, Sandra; Avery, Vicky M.</div><div class="citationInfo"><span class="NLM_cas:title">Malaria Journal</span>
+        (<span class="NLM_cas:date">2013</span>),
+    <cas:volume xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">12</cas:volume>
+        (<span class="NLM_cas:issue"></span>),
+    <span class="NLM_cas:pages">408/1-408/15, 15 pp.</span> CODEN: <cas:coden xmlns:cas="http://www.cas.org/citations" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">MJAOAZ</cas:coden>;
+        ISSN:<span class="NLM_cas:issn">1475-2875</span>.
+    
+            (<span class="NLM_cas:orgname">BioMed Central Ltd.</span>)
+        </div><div class="casAbstract">Background: Plasmodium falciparum gametocytes, specifically mature stages, are the only stage in man transmissible to the mosquito vector responsible for malaria transmission.  Anti-malarial drugs capable of killing these forms are considered essential for the eradication of malaria.  The comprehensive profiling of in vitro activity of anti-malarial compds. against both early (I-III) and late (IV-V) stage P. falciparum gametocytes, along with the high throughput screening (HTS) outcomes from the MMV malaria box are described.  Method: Two anti-gametocyte HTS assays based on confocal fluorescence microscopy, utilizing both a gametocyte specific protein (pfs16-Luc-GFP) and a viability marker (MitoTracker Red CM-H2XRos) (MTR), were used for the measurement of anti-gametocytocidal activity.  This combination provided a direct observation of gametocyte no. per assay well, while defining the viability of each gametocyte imaged.  Results: IC50 values were obtained for 36 current anti-malarial compds. for activities against asexual, early and late stage gametocytes.  The MMV malaria box was screened and actives progressed for IC50 evaluation.  Seven % of the "drug-like" and 21% of the "probe-like" compds. from the MMV malaria box demonstrated equiv. activity against both asexual and late stage gametocytes.  Conclusions: The assays described were shown to selectively identify compds. with gametocytocidal activity and have been demonstrated suitable for HTS with the capability of screening in the order of 20,000 compds. per screening campaign, two to three times per seven-day week.</div></div><div class="moreSciFi"><a title="Retrieve detailed record, substances, reactions and more for this article from SciFinder &#174;" href="https://scifinder.cas.org/scifinder/view/link_v1/reference.jsf?l=BmxxGlm8wGpKk3vbc59HXrVg90H21EOLACvtfcHk0li7wSeVq4gSTw"> >> More from SciFinder <sup>&#174;</sup></a></div><span class="casRefUrl">https://chemport.cas.org/services/resolver?origin=ACS&amp;resolution=options&amp;coi=1%3ACAS%3A528%3ADC%252BC2cXmvFehs7k%253D&amp;md5=5b38ae9bee99e2566f7765099ca7801c</span></div></div></div></div></li></ol></div></div></div><div id="figshare-widget"></div><script type="text/javascript">
+                    window.figureViewer={doi:'10.1021/acs.jmedchem.6b00723',path:'/appl/literatum/publisher/achs/journals/content/jmcmar/0/jmcmar.ahead-of-print/acs.jmedchem.6b00723/20160901',figures:[{i:'f_null',g:[{m:'jm-2016-00723u_0017.gif',l:'jm-2016-00723u_0017.jpeg'}]}
+                    ,{i:'fig1',g:[{m:'jm-2016-00723u_0002.gif',l:'jm-2016-00723u_0002.jpeg'}]}
+                    ,{i:'sch1',g:[{m:'jm-2016-00723u_0004.gif',l:'jm-2016-00723u_0004.jpeg'}]}
+                    ,{i:'sch2',g:[{m:'jm-2016-00723u_0005.gif',l:'jm-2016-00723u_0005.jpeg'}]}
+                    ,{i:'sch3',g:[{m:'jm-2016-00723u_0006.gif',l:'jm-2016-00723u_0006.jpeg'}]}
+                    ,{i:'fig2',g:[{m:'jm-2016-00723u_0003.gif',l:'jm-2016-00723u_0003.jpeg'}]}
+                    ]}</script><script type="text/javascript">window.refViewer={'ref1':['cit1'],'ref2':['cit2'],'ref3':['cit3a','cit3b','cit3c'],'ref4':['cit4'],'ref5':['cit5'],'ref6':['cit6'],'ref7':['cit7'],'ref8':['cit8a','cit8b'],'ref9':['cit9a','cit9b'],'ref10':['cit10'],'ref11':['cit11'],'ref12':['cit12'],'ref13':['cit13'],'ref14':['cit14a','cit14b'],'ref15':['cit15']}</script>
+                        </article>
+                        <div id="supInfoBox" class="supInfoBoxOnFTP ">
+                            
+
+
+
+
+
+<div class="sup-info-attachements">
+    
+    <ul>
+        
+            <li class="decorationNone">
+                <h3>
+                    
+
+                    <div class='suppl-file-img img-pdf'></div>
+                        PDF
+                </h3>
+                <ul>
+                    
+                        <li>
+                            <a href="/doi/suppl/10.1021/acs.jmedchem.6b00723/suppl_file/jm6b00723_si_001.pdf">
+                                
+                                jm6b00723_si_001.pdf
+                                
+                                (399.47
+                                kB)
+                            </a>
+                        </li>
+                    
+                </ul>
+            </li>
+        
+            <li class="decorationNone">
+                <h3>
+                    
+
+                    <div class='suppl-file-img img-csv'></div>
+                        
+                </h3>
+                <ul>
+                    
+                        <li>
+                            <a href="/doi/suppl/10.1021/acs.jmedchem.6b00723/suppl_file/jm6b00723_si_002.csv">
+                                
+                                jm6b00723_si_002.csv
+                                
+                                (2.73
+                                kB)
+                            </a>
+                        </li>
+                    
+                </ul>
+            </li>
+        
+    </ul>
+    <div class="supplementInfoMessage" data-pb-dropzone="supplementInfoMessage">
+        <pb2:renderDropzone widget="Widget type: literatumPublicationContentWidget, #d2a196f9-55e7-492a-9643-735a41b61a8c" dropzone="supplementInfoMessage" />
+    </div>
+</div>
+                        </div>
+                    
+            </div>
+            <div class="tab tab-pane" id="relatedContent">
+                
+
+
+
+
+
+
+            </div>
+            
+
+        </div>
+        
+
+
+
+
+
+
+
+
+
+
+    
+</div>
+    </div>
+<input id="viewLargeImageCaption" type="hidden" value="View Large Image" /></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget citingRelatedContent none  widget-none" id="f7276e41-a542-4df4-95ec-7d4523771d8a"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none "><div class="decorated-tabs tabs tabs-widget layout-tabs"><ul class="tab-nav citingRelatedNav"><li><a href="#tabs-1">Citing Articles</a></li><li><a href="#tabs-2">Related Content</a></li></ul><div class="tab-content"><div id="tabs-1" class="tab-pane"><div class="cited-content"><a id="citing" name="citing"></a><p>Citation data is made available by participants in <a href="http://www.crossref.org">CrossRef's</a> Cited-by Linking
+                                service.  For a more comprehensive list of citations to this article, users are
+                                encouraged to perform a search in <a href="http://scifinder.cas.org">SciFinder</a>.
+                            </p><ul id="citedBy"><li><img src="/appl/literatum/publisher/achs/journals/covergifs/jmcmar/0/cover.jpg" alt="Cover Image" class="cover" /><h2><div class="art_title linkable"><a href="/doi/abs/10.1021/acs.jmedchem.6b01486">In Vivo and In Vitro Optimization of Screening Antimalarial Hits toward Lead Molecules for Preclinical Development</a></div></h2><div class="contributors"><span class="hlFld-ContribAuthor ">Tony<span class="NLM_x"> </span>Fröhlich</span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve"> and </x></span><span class="hlFld-ContribAuthor ">Svetlana B.<span class="NLM_x"> </span>Tsogoeva</span><span class="NLM_x"><x xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:ACS="http://namespace.acs.org/2008/acs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xml:space="preserve"> </x></span></div><div><cite><span class="NLM_source">Journal of Medicinal Chemistry</span></cite> <strong>2016</strong> Article ASAP</div><div class="deliverFormatsLinks"><a href="/doi/abs/10.1021/acs.jmedchem.6b01486">Abstract</a>
+                | <a href="/doi/full/10.1021/acs.jmedchem.6b01486" title="View the Full Text HTML">Full Text HTML</a>
+            | <a target="_blank" title="Full-Text PDF" href="/doi/pdf/10.1021/acs.jmedchem.6b01486">PDF</a>
+            | <a title="Full-Text Enhanced PDF" target="_blank" href="/doi/pdfplus/10.1021/acs.jmedchem.6b01486">PDF w/ Links</a></div></li></ul></div></div><div id="tabs-2" class="tab-pane"><div id="relatedArticles"><h3 class="authorsHead">Other ACS content by these authors:</h3><ul class="oneline"><li><a href="/author/Baraga%C3%B1a%2C+Beatriz">Beatriz Baragaña</a></li><li><a href="/author/Norcross%2C+Neil+R">Neil R. Norcross</a></li><li><a href="/author/Wilson%2C+Caroline">Caroline Wilson</a></li><li><a href="/author/Porzelle%2C+Achim">Achim Porzelle</a></li><li><a href="/author/Hallyburton%2C+Irene">Irene Hallyburton</a></li><li><a href="/author/Grimaldi%2C+Raffaella">Raffaella Grimaldi</a></li><li><a href="/author/Osuna-Cabello%2C+Maria">Maria Osuna-Cabello</a></li><li><a href="/author/Norval%2C+Suzanne">Suzanne Norval</a></li><li><a href="/author/Riley%2C+Jennifer">Jennifer Riley</a></li><li><a href="/author/Stojanovski%2C+Laste">Laste Stojanovski</a></li><li><a href="/author/Simeons%2C+Frederick+R+C">Frederick R. C. Simeons</a></li><li><a href="/author/Wyatt%2C+Paul+G">Paul G. Wyatt</a></li><li><a href="/author/Delves%2C+Michael+J">Michael J. Delves</a></li><li><a href="/author/Meister%2C+Stephan">Stephan Meister</a></li><li><a href="/author/Duffy%2C+Sandra">Sandra Duffy</a></li><li><a href="/author/Avery%2C+Vicky+M">Vicky M. Avery</a></li><li><a href="/author/Winzeler%2C+Elizabeth+A">Elizabeth A. Winzeler</a></li><li><a href="/author/Sinden%2C+Robert+E">Robert E. Sinden</a></li><li><a href="/author/Wittlin%2C+Sergio">Sergio Wittlin</a></li><li><a href="/author/Frearson%2C+Julie+A">Julie A. Frearson</a></li><li><a href="/author/Gray%2C+David+W">David W. Gray</a></li><li><a href="/author/Fairlamb%2C+Alan+H">Alan H. Fairlamb</a></li><li><a href="/author/Waterson%2C+David">David Waterson</a></li><li><a href="/author/Campbell%2C+Simon+F">Simon F. Campbell</a></li><li><a href="/author/Willis%2C+Paul">Paul Willis</a></li><li><a href="/author/Read%2C+Kevin+D">Kevin D. Read</a></li><li><a href="/author/Gilbert%2C+Ian+H">Ian H. Gilbert</a></li></ul><ul class="additionalPubList recommendedPubList"><h3 class="relatedArticlesHead">Related Content:</h3><li><a href="/doi/abs/10.1021/acs.jmedchem.6b01022?src=recsys">Discovery of a Potent and Selective in Vivo Probe (GNE-272) for the Bromodomains of CBP/EP300</a><div class="achsLabel">Journal of Medicinal Chemistry</div><span class="entryAuthor normal hlFld-ContribAuthor">Crawford</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Romero</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Lai</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Tsui</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Taylor</span>, <span class="entryAuthor normal hlFld-ContribAuthor">de Leon Boenig</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Noland</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Murray</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Ly</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Choo</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Hunsaker</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Chan</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Merchant</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Kharbanda</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Gascoigne</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Kaufman</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Beresini</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Liao</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Liu</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Chen</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Chen</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Conery</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Côté</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Jayaram</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Jiang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Kiefer</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Kleinheinz</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Li</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Maher</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Pardo</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Poy</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Spillane</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Wang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Wang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Wei</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Xu</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Xu</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Yen</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Zawadzke</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Zhu</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Bellon</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Cummings</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Cochran</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Albrecht</span>, and <span class="entryAuthor normal hlFld-ContribAuthor">Magnuson</span> <div class="recoPubMetaData"><span><span class="bold"></span> <em>0</em> (0), </span></div><div class="recoPubAbstract"><span><span class="bold">Abstract:</span> The single bromodomain of the closely related transcriptional regulators CBP/EP300 is a target of much recent interest in cancer and immune system regulation. A co-crystal structure of a ligand-efficient screening hit and the CBP bromodomain guided ...<sub></sub><sub></sub><sub></sub></span></div><div class="linkbar recoPublinkbar"><a href="/doi/abs/10.1021/acs.jmedchem.6b01022?src=recsys">Abstract</a> | <a href="/doi/full/10.1021/acs.jmedchem.6b01022?src=recsys">Full Text HTML</a> | <a href="/doi/pdfplus/10.1021/acs.jmedchem.6b01022?src=recsys">PDF w/ Links</a> | <a href="/doi/pdf/10.1021/acs.jmedchem.6b01022?src=recsys">Hi-Res PDF</a></div></li><li><a href="/doi/abs/10.1021/acs.jmedchem.6b00442?src=recsys">Hit-to-Lead Optimization of a Novel Class of Potent, Broad-Spectrum Trypanosomacides</a><div class="achsLabel">Journal of Medicinal Chemistry</div><span class="entryAuthor normal hlFld-ContribAuthor">Russell</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Rahmani</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Jones</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Newson</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Neilde</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Cotillo</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Rahmani Khajouei</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Ferrins</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Qureishi</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Nguyen</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Martinez-Martinez</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Weaver</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Kaiser</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Riley</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Thomas</span>, <span class="entryAuthor normal hlFld-ContribAuthor">De Rycker</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Read</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Flematti</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Ryan</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Tanghe</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Rodriguez</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Charman</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Kessler</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Avery</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Baell</span>, and <span class="entryAuthor normal hlFld-ContribAuthor">Piggott</span> <div class="recoPubMetaData"><span><span class="bold"></span> <em>0</em> (0), </span></div><div class="recoPubAbstract"><span><span class="bold">Abstract:</span> The parasitic trypanosomes <i>Trypanosoma brucei</i> and <i>T. cruzi</i> are responsible for significant human suffering in the form of human African trypanosomiasis (HAT) and Chagas disease. Drugs currently available to treat these neglected diseases leave much to be ...</span></div><div class="linkbar recoPublinkbar"><a href="/doi/abs/10.1021/acs.jmedchem.6b00442?src=recsys">Abstract</a> | <a href="/doi/full/10.1021/acs.jmedchem.6b00442?src=recsys">Full Text HTML</a> | <a href="/doi/pdfplus/10.1021/acs.jmedchem.6b00442?src=recsys">PDF w/ Links</a> | <a href="/doi/pdf/10.1021/acs.jmedchem.6b00442?src=recsys">Hi-Res PDF</a></div></li><li><a href="/doi/abs/10.1021/acs.jmedchem.6b00741?src=recsys">No Denying It: Medicinal Chemistry Training Is in Big Trouble</a><div class="achsLabel">Journal of Medicinal Chemistry</div><span class="entryAuthor normal hlFld-ContribAuthor">Rafferty</span> <div class="recoPubMetaData"><span><span class="bold"></span> <em>0</em> (0), </span></div><div class="recoPubAbstract"><span><span class="bold">Abstract:</span> There has been little consensus between the pharmaceutical industry and academic communities concerning the best approach to train medicinal chemists for drug discovery. For decades the pharmaceutical industry has shown preference for synthetic organic ...</span></div><div class="linkbar recoPublinkbar"><a href="/doi/abs/10.1021/acs.jmedchem.6b00741?src=recsys">Abstract</a> | <a href="/doi/full/10.1021/acs.jmedchem.6b00741?src=recsys">Full Text HTML</a> | <a href="/doi/pdfplus/10.1021/acs.jmedchem.6b00741?src=recsys">PDF w/ Links</a> | <a href="/doi/pdf/10.1021/acs.jmedchem.6b00741?src=recsys">Hi-Res PDF</a></div></li><li><a href="/doi/abs/10.1021/acs.jmedchem.6b00618?src=recsys">Small Molecule Kinase Inhibitors for the Treatment of Brain Cancer</a><div class="achsLabel">Journal of Medicinal Chemistry</div><span class="entryAuthor normal hlFld-ContribAuthor">Heffron</span> <div class="recoPubMetaData"><span><span class="bold"></span> <em>0</em> (0), </span></div><div class="recoPubAbstract"><span><span class="bold">Abstract:</span> In addition to each of the factors that govern the identification of a successful oncology drug candidate, drug discovery aimed at treating neurological cancer must also consider the presence of the blood–brain barrier (BBB). The high level of expression ...</span></div><div class="linkbar recoPublinkbar"><a href="/doi/abs/10.1021/acs.jmedchem.6b00618?src=recsys">Abstract</a> | <a href="/doi/full/10.1021/acs.jmedchem.6b00618?src=recsys">Full Text HTML</a> | <a href="/doi/pdfplus/10.1021/acs.jmedchem.6b00618?src=recsys">PDF w/ Links</a> | <a href="/doi/pdf/10.1021/acs.jmedchem.6b00618?src=recsys">Hi-Res PDF</a></div></li><li><a href="/doi/abs/10.1021/acs.jmedchem.6b00995?src=recsys">Discovery of a Noncovalent, Mutant-Selective Epidermal Growth Factor Receptor Inhibitor</a><div class="achsLabel">Journal of Medicinal Chemistry</div><span class="entryAuthor normal hlFld-ContribAuthor">Chan</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Hanan</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Bowman</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Bryan</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Burdick</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Chan</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Chen</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Clausen</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Dela Vega</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Dotson</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Eigenbrot</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Elliott</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Heald</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Jackson</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Knight</span>, <span class="entryAuthor normal hlFld-ContribAuthor">La</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Lainchbury</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Malek</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Purkey</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Schaefer</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Schmidt</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Seward</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Sideris</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Shao</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Wang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Yeap</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Yen</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Yu</span>, and <span class="entryAuthor normal hlFld-ContribAuthor">Heffron</span> <div class="recoPubMetaData"><span><span class="bold">2016</span> <em>59</em> (19), pp 9080&ndash;9093</span></div><div class="recoPubAbstract"><span><span class="bold">Abstract:</span> Inhibitors targeting the activating mutants of the epidermal growth factor receptor (EGFR) have found success in the treatment of EGFR mutant positive non-small-cell lung cancer. A secondary point mutation (T790M) in the inhibitor binding site has been ...<sub></sub><sub></sub><sub></sub><sub></sub></span></div><div class="linkbar recoPublinkbar"><a href="/doi/abs/10.1021/acs.jmedchem.6b00995?src=recsys">Abstract</a> | <a href="/doi/full/10.1021/acs.jmedchem.6b00995?src=recsys">Full Text HTML</a> | <a href="/doi/pdfplus/10.1021/acs.jmedchem.6b00995?src=recsys">PDF w/ Links</a> | <a href="/doi/pdf/10.1021/acs.jmedchem.6b00995?src=recsys">Hi-Res PDF</a></div></li><li><a href="/doi/abs/10.1021/acs.jmedchem.6b00676?src=recsys">Synthesis and Antiobesity Properties of 6-(4-Chlorophenyl)-3-(4-((3,3-difluoro-1-hydroxycyclobutyl)methoxy)-3-methoxyphenyl)thieno[3,2-<i>d</i>]pyrimidin-4(3<i>H</i>)-one (BMS-814580): A Highly Efficacious Melanin Concentrating Hormone Receptor 1 (MCHR1) Inhibitor</a><div class="achsLabel">Journal of Medicinal Chemistry</div><span class="entryAuthor normal hlFld-ContribAuthor">Ahmad</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Washburn</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Hernandez</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Bisaha</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Ngu</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Wang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Pelleymounter</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Longhi</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Flynn</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Azzara</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Rohrbach</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Devenny</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Rooney</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Thomas</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Glick</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Godonis</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Harvey</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Zhang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Gemzik</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Janovitz</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Huang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Zhang</span>, <span class="entryAuthor normal hlFld-ContribAuthor">Robl</span>, and <span class="entryAuthor normal hlFld-ContribAuthor">Murphy</span> <div class="recoPubMetaData"><span><span class="bold">2016</span> <em>59</em> (19), pp 8848&ndash;8858</span></div><div class="recoPubAbstract"><span><span class="bold">Abstract:</span> The potent MCHR1 in vitro and in vivo antagonist activity of a series of cyclic tertiary alcohols derived from compound <b>2b</b> is described. Subsequent pharmacokinetic and pharmacodynamic studies identified BMS-814580 (compound <b>10</b>) as a highly efficacious ...</span></div><div class="linkbar recoPublinkbar"><a href="/doi/abs/10.1021/acs.jmedchem.6b00676?src=recsys">Abstract</a> | <a href="/doi/full/10.1021/acs.jmedchem.6b00676?src=recsys">Full Text HTML</a> | <a href="/doi/pdfplus/10.1021/acs.jmedchem.6b00676?src=recsys">PDF w/ Links</a> | <a href="/doi/pdf/10.1021/acs.jmedchem.6b00676?src=recsys">Hi-Res PDF</a></div></li></ul></div></div></div></div></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+    <div class="width_7_24">
+        <div data-pb-dropzone="right" class="pb-autoheight">
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-frame none article-rightCol widget-regular  widget-compact-all" id="067d2636-8e51-4c5b-ab96-1f9f356e2d63"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-regular  body-compact-all"><div data-pb-dropzone="contents">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-bookmark-share alignCenter  widget-none" id="38e82894-a98f-40d3-9bce-ee8aa23396f5"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none "><!-- AddThis Button BEGIN -->
+<div class="addthis_toolbox addthis_default_style addthis_32x32_style">
+        <a class="addthis_button_twitter"></a>
+        <a class="addthis_button_facebook"></a>
+        <a class="addthis_button_google_plusone_share"></a>
+        <a class="addthis_button_email"></a>
+    <a class="addthis_button_compact"></a>
+</div>
+<script type="text/javascript">
+    var script = document.createElement('script');
+    script.type='text/javascript';
+    script.src='//s7.addthis.com/js/250/addthis_widget.js#pubid=ra-553ffb6a26ba3f77';
+    script.async = true;
+    $('head').append(script)
+</script>
+<!-- AddThis Button END --></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget publicationFormatLinks none  widget-none  widget-compact-all" id="e665b162-cd85-4a56-ab94-9d58c9e3b43a"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="publicationFormatCont">
+    
+    
+    
+            <label class="sideConetntHeader">Article Options</label>
+        
+
+    <ul class="publicationFormatList icons">
+
+        
+            <li class="icon-item icon-item-24px active-view-pdf">
+                <a href="/doi/ipdf/10.1021/acs.jmedchem.6b00723" title="ACS ActiveView PDF" target="_blank">
+                    ACS ActiveView PDF
+                    <div class="icon-24px"></div>
+                </a>
+                <div class="details">Hi-Res Print, Annotate, Reference QuickView</div>
+            </li>
+        
+
+        
+            <li class="icon-item icon-item-24px subordinate pdf-high-res">
+                
+                <a href="/doi/pdf/10.1021/acs.jmedchem.6b00723" title="High-Res PDF: 1776 KB" target="_blank">
+                    PDF <span class="details">(1776 KB)</span>
+
+                    <div class="icon-24px"></div>
+                </a>
+            </li>
+        
+
+        
+            <li class="icon-item icon-item-24px subordinate pdf-low-res">
+                
+                <a href="/doi/pdfplus/10.1021/acs.jmedchem.6b00723" title="Low-Res PDF: 588 KB" target="_blank">
+                    PDF w/ Links <span class="details">(588 KB)</span>
+
+                    <div class="icon-24px"></div>
+                </a>
+            </li>
+        
+
+        
+            <li class="icon-item icon-item-24px subordinate full-text-html active">
+                <a href="/doi/full/10.1021/acs.jmedchem.6b00723" title="Full Text HTML">
+                    Full Text HTML
+                    <div class="icon-24px"></div>
+                </a>
+            </li>
+        
+    </ul>
+
+    <ul class="publicationFormatrightList">
+        <li class="">
+            <a href="/doi/abs/10.1021/acs.jmedchem.6b00723" title="View the Abstract">
+                Abstract
+            </a>
+        </li>
+        
+            <li class="">
+                <a href="/doi/suppl/10.1021/acs.jmedchem.6b00723">
+                    Supporting Info
+                </a>
+            </li>
+        
+
+        
+            <li>
+                
+                        <a class="showFiguresLink" href="JavaScript:void(0);" onclick="showFigures(event); return false">
+                            Figures
+                        </a>
+                    
+
+            </li>
+        
+
+        
+            
+                    <li>
+                        
+                        <a onclick="showRef(event); return false;" href="JavaScript:void(0);" class="showRefLink">
+                            References
+                        </a>
+                    </li>
+                
+        
+        
+            <li class="citing-link">
+                <a href="/doi/full/10.1021/acs.jmedchem.6b00723#citing">
+                    Citing Articles
+                </a>
+            </li>
+        
+
+    </ul>
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none toolbar widget-none  widget-compact-all" id="c81a0122-0045-4ad2-9ed7-5743378e5b2e"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="chemworx-sidebar chemworx-entry icon-item-24px">
+  <a href="#" onclick="ACSPubs.platinum.addCitation(['10.1021/acs.jmedchem.6b00723']);return false;">
+    <span class="icon-24px"></span>
+    Add to ACS ChemWorx</a>
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumArticleToolsWidget none  widget-none  widget-compact-all" id="9f81f65c-f41b-4b98-a9f0-28dc0dbb08ed"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="articleTools">
+    
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+
+<div class="toolbar-section toolbar-tools-sharing">
+    <label class="toolbar-section-header">Tools &amp; Sharing</label>
+    <ul class="icons">
+        
+                
+                    <li class="icon-item icon-item-24px add-favorites">
+                        <a href="/personalize/addFavoritePublication?doi=10.1021%2Facs.jmedchem.6b00723" title="Add to Favorites">
+                            Add to Favorites
+                            <div class="icon-24px"></div>
+                        </a>
+                    </li>
+                
+                
+                    <li class="icon-item icon-item-24px download-citation">
+                        <a href="/action/showCitFormats?href=http%3A%2F%2Fpubs.acs.org%2Fdoi%2Ffull%2F10.1021%2Facs.jmedchem.6b00723&amp;doi=10.1021%2Facs.jmedchem.6b00723" title="Download Citation">
+                            Download Citation
+                            <div class="icon-24px"></div>
+                        </a>
+                    </li>
+                
+            
+        
+            <li class="icon-item icon-item-24px email-colleague citation-alerts">
+                <a href="/action/showMailPage?href=%2Fdoi%2Ffull%2F10.1021%2Facs.jmedchem.6b00723&amp;title=Discovery+of+a+Quinoline-4-carboxamide+Derivative+with+a+Novel+Mechanism+of+Action%2C+Multistage+Antimalarial+Activity%2C+and+Potent+in+Vivo+Efficacy&amp;doi=10.1021%2Facs.jmedchem.6b00723" title="Email a Colleague">
+                    
+                    
+                    Email a Colleague
+                    <div class="icon-24px"></div>
+                </a>
+            </li>
+        
+
+        
+            
+                <li class="icon-item icon-item-24px order-reprints">
+                    <a id="orderReprints" title="Order Commercial Reprints"
+                       href="http://services.acs.org/pubshelp/passthru.cgi?action=kb&item=1190"
+                       target="_blank">
+                        Order Reprints
+                        <div class="icon-24px"></div>
+                    </a>
+                </li>
+            
+            
+                
+                    <li class="icon-item icon-item-24px rights-permissions">
+                        <a id="rightsAndPermissions" title="Rights &amp; Permissions" href="/page/rightslinkno.jsp "
+                           target="_blank">
+                            Rights & Permissions
+                            <div class="icon-24px"></div>
+                        </a>
+                    </li>
+                
+            
+            
+                <li class="icon-item icon-item-24px citation-alerts">
+                    <a href="/action/addCitationAlert?doi=10.1021%2Facs.jmedchem.6b00723" title="Citation Alerts">
+                        Citation Alerts
+                        <div class="icon-24px"></div>
+                    </a>
+                </li>
+            
+        
+    </ul>
+</div>
+        
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+            
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-frame none  widget-none  widget-border-toggle widget-compact-all" id="cd9ede2c-2a1d-4310-867b-8e5effc7cf54"  >
+        
+        
+
+        <div class="wrapped " >
+            <h1 class="widget-header header-none  header-border-toggle header-compact-all">Metrics</h1>
+            <div class="widget-body body body-none  body-border-toggle body-compact-all"><div data-pb-dropzone="contents">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-frame none metrics-main widget-none  widget-compact-all" id="657f3034-5703-45e5-a18e-4d77374a21b8"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div data-pb-dropzone="contents">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumContentItemHistory none  widget-none" id="764a4ee4-9265-43f8-8a38-36480fcd64fa"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none "><div>Received 10 May 2016</div>
+
+
+
+
+
+
+
+    
+    <div>Published online 10 September 2016</div></div>
+        </div>
+    </div>
+    
+</div></div>
+        </div>
+    </div>
+    
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget literatumSciFinderWidget none  widget-none  widget-compact-all" id="3adc9478-c3fb-4127-b9b7-650d0b059113"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div id="casSection" class="toolbar-section toolbar-sci-finder">
+            <div class="toolbar-section-header">
+                
+                        <img class="sciFinderLogo" src="/pb-assets/images/new-scifinder.png" alt="SciFinder Subscribers" />
+                    
+                <a href="https://scifinder.cas.org/" target="_blank">
+                    <button type="submit">Sign in</button>
+                </a>
+            </div>
+            <ul class="cas-links">
+                
+                    
+                    <li class="first">
+                        <a href="/action/clickThrough?id=202424&amp;url=https%3A%2F%2Fscifinder.cas.org%2Fscifinder%2Fview%2Flink_v1%2Freference.jsf%3Fl%3DBmxxGlm8wGqsSHCu5d8w-LVg90H21EOLACvtfcHk0liEcrr6OL7OYw&amp;loc=%2FControllerServlet&amp;pubId=40026035&amp;placeholderId=3130" title="Retrieve Detailed Record of this Article" target="scifinder">Retrieve Detailed Record of this Article</a>
+                    </li>
+                
+                    
+                    <li class="">
+                        <a href="/action/clickThrough?id=202432&amp;url=https%3A%2F%2Fscifinder.cas.org%2Fscifinder%2Fview%2Flink_v1%2FsubstancesFromReference.jsf%3Fl%3D4t9nkuNz3tw0bBf2vQptEltoDFflTVYFQkCTEVQ_hd2IqWT69oQQGJ2-KSROgajBtQwD9OmoEd3ihSO40pnVLTkF_XEZq-bW&amp;loc=%2FControllerServlet&amp;pubId=40026035&amp;placeholderId=3130" title="Retrieve Substances Indexed for this Article" target="scifinder">Retrieve Substances Indexed for this Article</a>
+                    </li>
+                
+                    
+                    <li class="">
+                        <a href="/action/clickThrough?id=202448&amp;url=https%3A%2F%2Fscifinder.cas.org%2Fscifinder%2Fview%2Flink_v1%2Fcited.jsf%3Fl%3DAkUi5EvKt81oKPlj93mNSYzzf1b8kx8etrnDmCxc-CThi25Vg2O3MkOtG_TRYJhi&amp;loc=%2FControllerServlet&amp;pubId=40026035&amp;placeholderId=3130" title="Retrieve All References Cited for this Article" target="scifinder">Retrieve All References Cited for this Article</a>
+                    </li>
+                
+                    
+                    <li class="last">
+                        <a href="/action/clickThrough?id=202456&amp;url=https%3A%2F%2Fscifinder.cas.org%2Fscifinder%2Fview%2Flink_v1%2Fciting.jsf%3Fl%3Dg2Ei4BFBAtcGbHEaWbzAaqxIcK7l3zD4tWD3QfbUQ4sAK-19weTSWIRyuvo4vs5j&amp;loc=%2FControllerServlet&amp;pubId=40026035&amp;placeholderId=3130" title="Retrieve All References Citing this Article" target="scifinder">Retrieve All References Citing this Article</a>
+                    </li>
+                
+            </ul>
+            
+                <form id="sci-finder-search--modes" class="sci-finder-form" action="#" >
+                    <h5>Explore by:</h5>
+                    
+                        <label for="sci-finder-article-author">
+                            <input onclick="toggleSFinterface(this);" id="sci-finder-article-author" type="radio" name="sci-finder-explore" value="article-authors" checked="checked" />
+                            Author of this
+                            
+                                    Article
+                                
+                        </label>
+                    
+                    <label for="sci-finder-any-author">
+                        <input onclick="toggleSFinterface(this);" id="sci-finder-any-author" type="radio" name="sci-finder-explore" value="any-author" />
+                        Any Author
+                    </label>
+                    <label for="sci-finder-research-topic">
+                        <input onclick="toggleSFinterface(this);" id="sci-finder-research-topic" type="radio" name="sci-finder-explore" value="research-topic" />
+                        Research Topic
+                    </label>
+                    <hr/>
+                </form>
+
+                
+                    <form action="/action/sciFinderSearch" id="sci-finder-search--article-authors" name="sfArtAuthorsLayer" class="sci-finder-form" method="post" target="scifinder"><label for="science-finder-article-author" class="science-finder-article-author">
+                            <select id="science-finder-article-author" name="authorName">
+
+                                
+                                    <option>Baragaña, Beatriz</option>
+                                
+                                    <option>Norcross, Neil R.</option>
+                                
+                                    <option>Wilson, Caroline</option>
+                                
+                                    <option>Porzelle, Achim</option>
+                                
+                                    <option>Hallyburton, Irene</option>
+                                
+                                    <option>Grimaldi, Raffaella</option>
+                                
+                                    <option>Osuna-Cabello, Maria</option>
+                                
+                                    <option>Norval, Suzanne</option>
+                                
+                                    <option>Riley, Jennifer</option>
+                                
+                                    <option>Stojanovski, Laste</option>
+                                
+                                    <option>Simeons, Frederick R. C.</option>
+                                
+                                    <option>Wyatt, Paul G.</option>
+                                
+                                    <option>Delves, Michael J.</option>
+                                
+                                    <option>Meister, Stephan</option>
+                                
+                                    <option>Duffy, Sandra</option>
+                                
+                                    <option>Avery, Vicky M.</option>
+                                
+                                    <option>Winzeler, Elizabeth A.</option>
+                                
+                                    <option>Sinden, Robert E.</option>
+                                
+                                    <option>Wittlin, Sergio</option>
+                                
+                                    <option>Frearson, Julie A.</option>
+                                
+                                    <option>Gray, David W.</option>
+                                
+                                    <option>Fairlamb, Alan H.</option>
+                                
+                                    <option>Waterson, David</option>
+                                
+                                    <option>Campbell, Simon F.</option>
+                                
+                                    <option>Willis, Paul</option>
+                                
+                                    <option>Read, Kevin D.</option>
+                                
+                                    <option>Gilbert, Ian H.</option>
+                                
+                            </select>
+
+                        </label>
+                        <button type="submit">Search</button>
+                        <input type="hidden" name="searchAuthorsFromContent" value="Search" /></form>
+                
+
+                <form action="/action/sciFinderSearch" id="science-finder-search--article-authors" name="science-finder-search--article-authors" class="sci-finder-form hidden" method="post" target="scifinder"><label for="sci-finder-author-last-name">
+                        <span class="sci-finder-name">Last *</span>
+                        <input id="sci-finder-author-last-name" type="text" name="lastName" value="" size="15" />
+                        
+                    </label>
+                    <label for="sci-finder-author-first-name">
+                        <span class="sci-finder-name">First</span>
+                        <input id="sci-finder-author-first-name" type="text" name="firstName" value="" size="15" />
+                    </label>
+                    <label for="sci-finder-author-middle-name">
+                        <span class="sci-finder-name">Middle</span>
+                        <input id="sci-finder-author-middle-name" type="text" name="middleName" value="" size="15" />
+                    </label>
+                    <button type="submit">Search</button>
+                    <input type="hidden" name="searchAnyAuthor" value="Search" /></form>
+
+                <form action="/action/sciFinderSearch" id="sci-finder-search--topics" name="sfTopicLayer" class="sci-finder-form hidden" method="post" target="scifinder"><label for="sci-finder-topic">
+                        <span>Topic *</span>
+                        <input id="sci-finder-topic" type="text" name="topic" value="" size="15" />
+                        
+                    </label>
+                    <label for="sci-finder-patents-only">
+                        <input id="sci-finder-patents-only" type="checkbox" name="patentsOnly" value="" size="15" />
+                        <span>Patents only search</span>
+                    </label>
+                    <button type="submit">Search</button>
+                    <input type="hidden" name="searchTopic" value="Search" /></form>
+            
+        </div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+            
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget layout-frame none cen-feed widget-regular  widget-border-toggle widget-compact-all" id="9872c8c4-5cdd-48fc-a3b4-ec2b200239a2"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-regular  body-border-toggle body-compact-all"><div data-pb-dropzone="contents">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none  widget-compact-all" id="dcada731-30cd-4319-8aa8-8b5d120456ee"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="cen-feed-header">
+<img src="/pb-assets/images/cen-feed-logo.png" alt="C&amp;EN Online News" />
+</div></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-rss-feed-reader none  widget-none" id="0307c24f-282e-433c-85ba-1f326495f833"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none "><!--content loaded via ajax--></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none  widget-compact-all" id="28df3542-cb22-4c45-8f2f-6af957074733"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="horizontal-links">
+  <a href="http://cen.acs.org">C&amp;EN Online</a>
+  <a href="http://cen.acs.org/currentIssue.html">Current Issue</a>
+  <a href="http://feeds.feedburner.com/cen_latestnews">News RSS Feed</a>
+</div>
+
+<div class="archive-link">
+  <strong><a href="/journal/cenear">More From Archives</a></strong>
+</div></div>
+        </div>
+    </div>
+    
+</div></div>
+        </div>
+    </div>
+    
+</div></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+</div></div>
+        </div>
+    </div>
+    
+</div></div>
+        </div>
+    </div>
+    
+    </div>
+</div><!--end pagefulltext--></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget pageFooter none  widget-none  widget-compact-all" id="65b3a46e-5016-4d9a-9cc0-1224e4bbf46a"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><footer class="page-footer">
+    <div data-pb-dropzone="main">
+    
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+                
+            
+            
+                
+                
+                
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none  widget-compact-all" id="711aa7bf-5b37-481e-81f0-992b43dca726"  >
+        
+        
+
+        <div class="wrapped " >
+            
+            <div class="widget-body body body-none  body-compact-all"><div class="acs-footer-wrap follow-bar">
+    <div class="acs-footer">
+        <div id="pageFooterFollowBar">
+            <ul>
+                <li class="follow-acs"><a href="/page/follow.html" title="Follow ACS"></a></li>
+                <li class="follow-e-alerts"><a href="/page/follow.html" title="e-Alerts" onclick="ga('send','event', 'Footer', 'Follow Bar', 'E-Alerts Tab'); setTimeout(function(){this.location = 'http://pubs.acs.org/page/follow.html#e-alerts'}, 100); return false;"></a></li>
+                <li class="follow-facebook"><a href="/page/follow.html?widget=follow-pane-facebook" title="Facebook" onclick="ga('send','event', 'Footer', 'Follow Bar', 'Facebook Tab'); setTimeout(function(){this.location = 'http://pubs.acs.org/page/follow.html?widget=follow-pane-facebook'}, 100); return false;"></a></li>
+                <li class="follow-twitter"><a href="/page/follow.html?widget=follow-pane-twitter" title="Twitter" onclick="ga('send','event', 'Footer', 'Follow Bar', 'Twitter Tab'); setTimeout(function(){this.location = 'http://pubs.acs.org/page/follow.html?widget=follow-pane-twitter'}, 100); return false;"></a></li>
+                <li class="follow-rss"><a href="/page/follow.html?widget=follow-pane-rss" title="RSS Feeds" onclick="ga('send','event', 'Footer', 'Follow Bar', 'RSS Feeds Tab'); setTimeout(function(){this.location = 'http://pubs.acs.org/page/follow.html?widget=follow-pane-rss'}, 100); return false;"></a></li>
+                <li class="follow-podcasts"><a href="/page/follow.html?widget=follow-pane-podcasts" title="Podcasts" onclick="ga('send','event', 'Footer', 'Follow Bar', 'Podcasts Tab'); setTimeout(function(){this.location = 'http://pubs.acs.org/page/follow.html?widget=follow-pane-podcasts'}, 100); return false;"></a></li>
+                <li class="follow-youtube"><a href="/page/follow.html?widget=follow-pane-youtube" title="YouTube" onclick="ga('send','event', 'Footer', 'Follow Bar', 'YouTube Tab'); setTimeout(function(){this.location = 'http://pubs.acs.org/page/follow.html?widget=follow-pane-youtube'}, 100); return false;"></a></li>
+                <li class="follow-tools"><a href="/page/follow.html?widget=follow-pane-mobile" title="Mobile" onclick="ga('send','event', 'Footer', 'Follow Bar', 'Mobile Tab'); setTimeout(function(){this.location = 'http://pubs.acs.org/page/follow.html?widget=follow-pane-mobile'}, 100); return false;"></a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<div class="acs-footer-wrap footer-links">
+    <div class="acs-footer">
+        <div id="pageFooterLinks">
+            <div id="pageFooterAddress">
+                <img src="http://pubs.acs.org/templates/jsp/_style2/_achs/images/pubslogo-small.png">
+                <p>1155 Sixteenth Street N.W.<br>Washington, DC 20036</p>
+                <p><span class="beian">京ICP备13047075</span></p>
+                <p><a href="http://www.acs.org/content/acs/en/copyright.html" title="ACS Copyright Information">Copyright © 2016<br>American Chemical Society</a></p>
+            </div>
+            
+            <ul class="products">
+                <li><h3>Products</h3></li>
+                <li><a href="/action/showPublications?display=journals">Journals A–Z</a></li>
+                <li><a href="/page/books/index.html">eBooks</a></li>
+                <li><a href="/cen">C&amp;EN</a></li>
+                <li><a href="/cen-archives">C&amp;EN Archives</a></li>
+                <li><a href="/page/4librarians/products/archives/index.html">ACS Legacy Archives</a></li>
+                <li><a href="/r/acsmobile">ACS Mobile</a></li>
+                <li><a href="/page/audio-video/index.html">Video</a></li>
+            </ul>
+            <ul class="user-resources">
+                <li><h3>User Resources</h3></li>
+                <li><a href="/page/about-us.html">About Us</a></li>
+                <li><a href="/page/membership/index.html">ACS Members</a></li>
+                <li><a href="/page/4librarians/index.html">Librarians</a></li>
+                <li><a href="/page/4authors/index.html">Authors &amp; Reviewers</a></li>
+                <!-- <li><a href="/page/4authors/index.html">Students</a></li> -->
+                <li><a href="/page/demo/index.html">Website Demos</a></li>
+                <li><a href="http://www.acs.org/content/acs/en/privacy.html">Privacy Policy</a></li>
+                <li><a href="/?mobileUi=1">Mobile Site</a></li>
+            </ul>
+            <ul class="support">
+                <li><h3>Support</h3></li>
+                <li><a href="#" class="help">Get Help</a></li>
+                <li><a href="http://acsmediakit.org/acs-pubs/?utm_source=Footer&amp;utm_medium=Pubs&amp;utm_campaign=CEN">For Advertisers</a></li>
+                <li><a href="/page/4librarians/contact-us/index.html">Institutional Sales</a></li>
+                <li class="help" href="#"><a href="#" class="help help-chat">Live Chat</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<div class="acs-footer-wrap partners">
+    <div class="acs-footer">
+        <ul>
+            <li><h3>Partners</h3></li>
+            <li><a href="http://www.atypon.com" title="Atypon"><img src="/pb-assets/images/footer/atypon-logo.png" alt="Atypon"></a></li>
+            <li><a href="http://www.chorusaccess.org" title="CHORUS"><img src="/pb-assets/images/footer/chorus-logo.png" alt="CHORUS"></a></li>
+            <li><a href="http://publicationethics.org/" title="COPE"><img src="/pb-assets/images/footer/cope-logo.png" alt="COPE"></a></li>
+            <li><a href="http://www.projectcounter.org/" title="COUNTER"><img src="/pb-assets/images/footer/counter-logo.png" alt="COUNTER"></a></li>
+            <li><a href="http://www.crossref.org/" title="CrossRef"><img src="/pb-assets/images/footer/crossref-logo.png" alt="CrossRef"></a></li>
+            <li><a href="http://www.crossref.org/crosscheck/index.html" title="CrossCheck Depositor"><img src="/pb-assets/images/footer/crosscheck-logo.png" alt="CrossCheck Depositor"></a></li>
+            <li><a href="http://www.orcid.org/" title="Orcid"><img src="/pb-assets/images/footer/orcid-logo.png" alt="Orcid"></a></li>
+            <li><a href="http://www.portico.org/" title="Portico"><img src="/pb-assets/images/footer/portico-logo.png" alt="Portico"></a></li>
+        </ul>
+    </div>
+</div>
+
+<script src="https://1131784da7184e34e737-f2bb466c03e9d6b8c5e18a9c4f84e1a0.ssl.cf1.rackcdn.com/chat-pubs.js"></script>
+<script>
+ACSPubs.login.listenerActive = false;
+ACSPubs.login.listen = function (callback){
+        var done = false;
+        if(ACSPubs.login.listenerActive == false){
+            ACSPubs.login.listenerActive= true;
+            var interval = setInterval(function(){
+                if(document.cookie.match(/(?:^|;) ?ERIGHTS=([^;$]+)(?:;|$)/)){
+                    done = true;
+                    listenerActive = false;
+                    clearInterval(interval);
+                    return callback();
+                }
+            }, 1000);
+        }    
+    };</script></div>
+        </div>
+    </div>
+    
+
+
+
+    
+    
+    
+    
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+    
+    
+        
+    
+        
+    
+        
+    
+        
+    
+        
+            
+            
+            
+        
+    
+        
+    
+        
+    
+        
+    
+    
+    
+
+    
+    <div class="widget general-html none  widget-none" id="fe197482-aec7-44dd-8734-ca0859abfaa5"  >
+        
+        
+            
+        
+
+        <div class="wrapped " id='link-to-top'>
+            
+            <div class="widget-body body body-none "><script type="text/javascript">
+function backToTop() {
+    var offset1 = $('body').scrollTop();
+	var offset2 = $('html').scrollTop();
+	var offset = offset1 + offset2; /* because one of these will be zero, depending on browser */
+    var winWidth = $(window).width();
+    var winHeight = $(window).height();
+    var viewportBottom = offset + winHeight;
+    var linkTrigger = winHeight * 2;
+    var linkToTop = '<a id="linkToTop" style="display:none;" title="Return to top" href="#" onclick="$(\'body,html\').animate({scrollTop: $(\'body,html\').offset().top});return false;">&nbsp;<\/a>';
+
+    // insert link to top when scrolled past 2x the viewport height
+    // only show it if the user's window is big enough (<1110px)
+    if ($('#linkToTop').length && $('#linkToTop').is(':visible')) {
+        if (winWidth < 1110) {
+            $('#linkToTop').remove();
+		}
+        else if (viewportBottom < linkTrigger) {
+            $('#linkToTop').fadeOut();
+		}
+	}
+   	else if (winWidth > 1110 && viewportBottom > linkTrigger) {
+		if ($('#linkToTop').length==0) {
+			$('body').append(linkToTop);
+		}
+		$('#linkToTop').fadeIn();
+    }
+};
+$(function() {
+	setInterval("backToTop()", 1000);
+});
+
+// a general show/hide toggle function
+function toggleView(link, animate) {
+    var target = $(link).parents('div:eq(0)').find('.toggled');
+    var linkText = $(link).html();
+
+	if ($(target).is(':visible')) {
+		$(link).html(linkText.replace("Hide","View"));
+	}
+	else {
+		$(link).html(linkText.replace("View","Hide"));
+	}
+    if (!animate) {
+        $(target).toggle();
+	}
+	else {
+		$(target).fadeToggle();
+	}
+}
+</script>
+
+<script type="text/javascript">
+    var _elqQ = _elqQ || [];
+    _elqQ.push(['elqSetSiteId', '1913652004']);
+    _elqQ.push(['elqTrackPageView']);
+    (function () {
+    function async_load() {
+    var s = document.createElement('script'); s.type = 'text/javascript';
+    s.async = true; s.src = '//img.en25.com/i/elqCfg.min.js';
+    var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore (s, x);
+    }
+    if (window.addEventListener) window.addEventListener('DOMContentLoaded',
+    async_load, false);
+    else if (window.attachEvent) window.attachEvent('onload', async_load);
+    })();
+    </script></div>
+        </div>
+    </div>
+    
+    </div>
+</footer></div>
+        </div>
+    </div>
+    
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/test_reader_acs.py
+++ b/tests/test_reader_acs.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+test_reader_acs
+~~~~~~~~~~~~~~~
+
+Test ACS reader.
+
+:copyright: Copyright 2016 by Matt Swain.
+:license: MIT, see LICENSE file for more details.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import io
+import logging
+import os
+import unittest
+
+from chemdataextractor import Document
+from chemdataextractor.reader import AcsHtmlReader
+
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+class TestAcsHtmlReader(unittest.TestCase):
+
+    maxDiff = None
+
+    def test_detect(self):
+        """Test AcsHtmlReader can detect an ACS document."""
+        r = AcsHtmlReader()
+        fname = 'acs.jmedchem.6b00723.html'
+        f = io.open(os.path.join(os.path.dirname(__file__), 'data', 'acs', fname), 'rb')
+        content = f.read()
+        self.assertEqual(r.detect(content, fname=fname), True)
+
+    def test_direct_usage(self):
+        """Test AcsHtmlReader used directly to parse file."""
+        r = AcsHtmlReader()
+        fname = 'acs.jmedchem.6b00723.html'
+        f = io.open(os.path.join(os.path.dirname(__file__), 'data', 'acs', fname), 'rb')
+        content = f.read()
+        d = r.readstring(content)
+        self.assertEqual(len(d.elements), 198)
+
+    def test_document_usage(self):
+        """Test AcsHtmlReader used via Document.from_file."""
+        fname = 'acs.jmedchem.6b00723.html'
+        f = io.open(os.path.join(os.path.dirname(__file__), 'data', 'acs', fname), 'rb')
+        d = Document.from_file(f, readers=[AcsHtmlReader()])
+        self.assertEqual(len(d.elements), 198)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Reference links with an immediate child element (e.g. sup) return None for their text property, raising an exception on the strip() call. Instead, use itertext() to get all nested text and join.