### PR TITLE
adding any kind of labels

### DIFF
--- a/chemdataextractor/parse/cem.py
+++ b/chemdataextractor/parse/cem.py
@@ -53,7 +53,7 @@ to_give = (I('to') + (I('give') | I('yield') | I('afford')) | I('afforded') | I(
 
 label_blacklist = R('^(31P|[12]H|[23]D|15N|14C|[4567890]\d+)$')
 
-prefixed_label = R('^(cis|trans)-((d-)?(\d{1,2}[A-Za-z]{0,2}[′″‴‶‷⁗]?)(-d)?|[LS]\d\d?)$')
+prefixed_label = R('^([Ll]eu|cis|trans)-((d-)?(\d{1,2}[A-Za-z]{0,2}[′″‴‶‷⁗]?)(-d)?|[LS]\d\d?)$')
 
 #: Chemical label. Very permissive - must be used in context to avoid false positives.
 strict_chemical_label = Not(label_blacklist) + (alphanumeric | roman_numeral | letter_number | prefixed_label)('label')

--- a/chemdataextractor/parse/cem.py
+++ b/chemdataextractor/parse/cem.py
@@ -53,7 +53,7 @@ to_give = (I('to') + (I('give') | I('yield') | I('afford')) | I('afforded') | I(
 
 label_blacklist = R('^(31P|[12]H|[23]D|15N|14C|[4567890]\d+)$')
 
-prefixed_label = R('^([Ll]eu|cis|trans)-((d-)?(\d{1,2}[A-Za-z]{0,2}[′″‴‶‷⁗]?)(-d)?|[LS]\d\d?)$')
+prefixed_label = R('^(cis|trans|[A-Za-z]{,3})-((d-)?(\d{1,2}[A-Za-z]{0,2}[′″‴‶‷⁗]?)(-d)?|[LS]\d\d?)$')
 
 #: Chemical label. Very permissive - must be used in context to avoid false positives.
 strict_chemical_label = Not(label_blacklist) + (alphanumeric | roman_numeral | letter_number | prefixed_label)('label')

--- a/chemdataextractor/parse/cem.py
+++ b/chemdataextractor/parse/cem.py
@@ -53,7 +53,7 @@ to_give = (I('to') + (I('give') | I('yield') | I('afford')) | I('afforded') | I(
 
 label_blacklist = R('^(31P|[12]H|[23]D|15N|14C|[4567890]\d+)$')
 
-prefixed_label = R('^(cis|trans|[A-Za-z]{,3})-((d-)?(\d{1,2}[A-Za-z]{0,2}[′″‴‶‷⁗]?)(-d)?|[LS]\d\d?)$')
+prefixed_label = R('^(trans|[A-Za-z]{,3})-((d-)?(\d{1,2}[A-Za-z]{0,2}[′″‴‶‷⁗]?)(-d)?|[LS]\d\d?)$')
 
 #: Chemical label. Very permissive - must be used in context to avoid false positives.
 strict_chemical_label = Not(label_blacklist) + (alphanumeric | roman_numeral | letter_number | prefixed_label)('label')

--- a/tests/test_parse_cem.py
+++ b/tests/test_parse_cem.py
@@ -170,6 +170,11 @@ class TestParseCem(unittest.TestCase):
         ]
         self.do_parse(s, expected)
 
+    def test_label_start(self):
+        s = '1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene (Leu-07)'
+        expected = ['<cem_phrase><cem><name>1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene</name><label>Leu-07</label></cem></cem_phrase>']
+        self.do_parse(s, expected)
+
 
 class TestParseCemHeading(unittest.TestCase):
 

--- a/tests/test_parse_cem.py
+++ b/tests/test_parse_cem.py
@@ -171,9 +171,16 @@ class TestParseCem(unittest.TestCase):
         self.do_parse(s, expected)
 
     def test_label_start(self):
-        s = '1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene (Leu-07)'
-        expected = ['<cem_phrase><cem><name>1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene</name><label>Leu-07</label></cem></cem_phrase>']
-        self.do_parse(s, expected)
+        s = ['1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene (Leu-07)',
+             '1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene (hi-07)',
+             '1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene (hife-07)']
+        expected = [
+            ['<cem_phrase><cem><name>1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene</name><label>Leu-07</label></cem></cem_phrase>'],
+            ['<cem_phrase><cem><name>1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene</name><label>hi-07</label></cem></cem_phrase>'],
+            ['<cem_phrase><cem><name>1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene</name></cem></cem_phrase>']
+        ]
+        for s_elem, expected_elem in zip(s, expected):
+            self.do_parse(s_elem, expected_elem)
 
 
 class TestParseCemHeading(unittest.TestCase):


### PR DESCRIPTION
I found that in some papers you can find something like this:

`1,3,5-Tricyano-2,4,6-tris(2-dimethylaminovinyl)benzene (Leu-07)`

and this is not allowed in the current grammar, so I decided to allow any kind of names at with length at least of 3 like `Leu`. @mcs07  