### PR TITLE
Fix: deprecated collections imports

### DIFF
--- a/chemdataextractor/config.py
+++ b/chemdataextractor/config.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import io
 import os
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import appdirs
 import yaml

--- a/chemdataextractor/config.py
+++ b/chemdataextractor/config.py
@@ -13,7 +13,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import io
 import os
-from collections.abc import MutableMapping
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 import appdirs
 import yaml

--- a/chemdataextractor/doc/document.py
+++ b/chemdataextractor/doc/document.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from abc import ABCMeta, abstractproperty
-import collections
+from collections.abc import Sequence
 import io
 import json
 import logging
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 
 
 @python_2_unicode_compatible
-class BaseDocument(six.with_metaclass(ABCMeta, collections.Sequence)):
+class BaseDocument(six.with_metaclass(ABCMeta, Sequence)):
     """Abstract base class for a Document."""
 
     def __repr__(self):

--- a/chemdataextractor/doc/document.py
+++ b/chemdataextractor/doc/document.py
@@ -13,10 +13,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from abc import ABCMeta, abstractproperty
-from collections.abc import Sequence
 import io
 import json
 import logging
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 import six
 

--- a/chemdataextractor/doc/text.py
+++ b/chemdataextractor/doc/text.py
@@ -12,9 +12,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 from abc import abstractproperty
-from collections.abc import Sequence
 import logging
 import re
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 import six
 

--- a/chemdataextractor/doc/text.py
+++ b/chemdataextractor/doc/text.py
@@ -12,7 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 from abc import abstractproperty
-import collections
+from collections.abc import Sequence
 import logging
 import re
 
@@ -113,7 +113,7 @@ class BaseText(BaseElement):
         return self.text
 
 
-class Text(collections.Sequence, BaseText):
+class Text(Sequence, BaseText):
     """A passage of text, comprising one or more sentences."""
 
     sentence_tokenizer = ChemSentenceTokenizer()

--- a/chemdataextractor/model.py
+++ b/chemdataextractor/model.py
@@ -14,7 +14,7 @@ from __future__ import unicode_literals
 
 import copy
 from abc import ABCMeta
-from collections import MutableSequence
+from collections.abc import MutableSequence
 import json
 import logging
 

--- a/chemdataextractor/model.py
+++ b/chemdataextractor/model.py
@@ -14,9 +14,13 @@ from __future__ import unicode_literals
 
 import copy
 from abc import ABCMeta
-from collections.abc import MutableSequence
 import json
 import logging
+
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    from collections import MutableSequence
 
 import six
 

--- a/chemdataextractor/parse/elements.py
+++ b/chemdataextractor/parse/elements.py
@@ -11,10 +11,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from collections.abc import Sequence
 import copy
 import logging
 import re
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from lxml.builder import E
 import six

--- a/chemdataextractor/parse/elements.py
+++ b/chemdataextractor/parse/elements.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-import collections
+from collections.abc import Sequence
 import copy
 import logging
 import re
@@ -309,7 +309,7 @@ class ParseExpression(BaseParserElement):
             exprs = list(exprs)
         if isinstance(exprs, six.text_type):
             self.exprs = [Word(exprs)]
-        elif isinstance(exprs, collections.Sequence):
+        elif isinstance(exprs, Sequence):
             if all(isinstance(expr, six.text_type) for expr in exprs):
                 exprs = map(Word, exprs)
             self.exprs = list(exprs)

--- a/chemdataextractor/scrape/entity.py
+++ b/chemdataextractor/scrape/entity.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from collections import Sequence
+from collections.abc import Sequence
 import json
 import logging
 

--- a/chemdataextractor/scrape/entity.py
+++ b/chemdataextractor/scrape/entity.py
@@ -11,9 +11,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from collections.abc import Sequence
 import json
 import logging
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 import six
 

--- a/chemdataextractor/scrape/selector.py
+++ b/chemdataextractor/scrape/selector.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from collections import Sequence
+from collections.abc import Sequence
 from copy import deepcopy
 import logging
 import re

--- a/chemdataextractor/scrape/selector.py
+++ b/chemdataextractor/scrape/selector.py
@@ -11,11 +11,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from collections.abc import Sequence
 from copy import deepcopy
 import logging
 import re
 from bs4 import UnicodeDammit
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from lxml.etree import XMLParser, fromstring, tostring
 from lxml.html import HTMLParser


### PR DESCRIPTION
Imports like Sequence, MutableSequence, etc. are deprecated since
python 3.3 and are removed from 3.8. This commit fixes these import
problems for users with python 3.8+

ref: https://github.com/python/cpython/issues/81505
